### PR TITLE
Update release script and dependencies

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -28,11 +28,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -43,7 +43,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v3
+      uses: github/codeql-action/autobuild@v4
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -57,4 +57,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - name: Post to a Slack channel
         id: slack
-        uses: slackapi/slack-github-action@v1
+        uses: slackapi/slack-github-action@v3
         with:
           payload: |
             {

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,6 +11,8 @@ jobs:
         id: slack
         uses: slackapi/slack-github-action@v3
         with:
+          webhook: ${{ secrets.PIPELINE_SLACK_CHANNEL_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
           payload: |
             {
             "text": "New release ${{github.ref_name}} for ${{github.event.repository.name}}.",

--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -12,16 +12,16 @@ jobs:
       id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           persist-credentials: false
       - name: Install pnpm
-        uses: pnpm/action-setup@v3
+        uses: pnpm/action-setup@v5
         with:
           version: latest
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 'lts/*'
           cache: 'pnpm'

--- a/.github/workflows/vulnerability-updates.yml
+++ b/.github/workflows/vulnerability-updates.yml
@@ -1,0 +1,28 @@
+name: Vulnerability update
+
+on:
+  issues:
+    types: [opened, labeled, reopened]
+  workflow_dispatch:
+
+concurrency:
+  group: vulnerability-update-${{ github.event_name }}-${{ github.event.issue.number || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  run:
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (
+        github.event_name == 'issues' &&
+        contains(github.event.issue.labels.*.name, 'vulnerability')
+      )
+    uses: commercelayer/.github/.github/workflows/dependencies-update-pnpm.yaml@main
+    with:
+      reviewers: "pviti"
+      use_milestone: false
+      run_test: true
+      run_build: true
+      run_check: true
+      issue_number: ${{ github.event_name == 'issues' && github.event.issue.number || '' }}
+    secrets: inherit

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![License](https://img.shields.io/npm/l/@commercelayer/sdk-utils.svg)](https://github.com/commercelayer/commercelayer-sdk-utils/blob/master/package.json)
 [![semantic-release: angular](https://img.shields.io/badge/semantic--release-angular-e10079?logo=semantic-release)](https://github.com/semantic-release/semantic-release)
 [![Release](https://github.com/commercelayer/commercelayer-sdk-utils/actions/workflows/semantic-release.yml/badge.svg)](https://github.com/commercelayer/commercelayer-sdk-utils/actions/workflows/semantic-release.yml)
-[![CodeQL](https://github.com/commercelayer/commercelayer-cli/actions/workflows/codeql-analysis.yml/badge.svg)](https://github.com/commercelayer/commercelayer-cli/actions/workflows/codeql-analysis.yml)
+[![CodeQL](https://github.com/commercelayer/commercelayer-sdk-utils/actions/workflows/codeql-analysis.yml/badge.svg)](https://github.com/commercelayer/commercelayer-sdk-utils/actions/workflows/codeql-analysis.yml)
 [![TypeScript](https://img.shields.io/badge/%3C%2F%3E-TypeScript%205-%230074c1.svg)](https://www.typescriptlang.org/)
 
 A JavaScript Library that makes even more easier to interact with [Commerce Layer API](https://docs.commercelayer.io/developers) using the official [JavaScript SDK](https://github.com/commercelayer/commercelayer-sdk).
@@ -24,7 +24,7 @@ CommerceLayerUtils(cl)
 await executeBatch(batch)
 ```
 
-#### SDK v7.x
+#### SDK v7.x (requires `^7.11.0`)
 
 Starting from SDK v7 you can take advantage of the tree shaking using only the resources that you really need.
 
@@ -342,6 +342,8 @@ const shipment = denormalizePayload<Shipment>(webhookPayload)
 
 This helper can be used to easily build the array of included resources to use in SDK query parameters.
 
+> **Note:** The `versions` resource has been removed from the Commerce Layer API and is no longer available in the include helper.
+
 ###### Standard include
 
 ```ts
@@ -385,6 +387,8 @@ io.customer.customer_group.addTo(queryFilter)
 ##### FilterHelper
 
 This helper can be used to easily build the object containing the filter predicates to use in SDK query parameters.
+
+> **Note:** The `versions` resource has been removed from the Commerce Layer API and is no longer available in the filter helper.
 
 ###### Standard filter
 

--- a/package.json
+++ b/package.json
@@ -47,20 +47,20 @@
   },
   "devDependencies": {
     "@biomejs/biome": "2.4.8",
-    "@commercelayer/js-auth": "^7.3.0",
-    "@commercelayer/sdk": "^7.10.0",
+    "@commercelayer/js-auth": "^7.4.2",
+    "@commercelayer/sdk": "^7.11.0",
     "@semantic-release/changelog": "^6.0.3",
     "@semantic-release/git": "^10.0.1",
-    "@types/node": "^24.12.0",
-    "@vitest/coverage-v8": "^4.1.2",
+    "@types/node": "^24.13.2",
+    "@vitest/coverage-v8": "^4.1.8",
     "conventional-changelog-conventionalcommits": "^9.3.1",
     "dotenv": "^16.6.1",
     "jsonapi-typescript": "^0.1.3",
-    "semantic-release": "^25.0.3",
+    "semantic-release": "^25.0.5",
     "tsup": "^8.5.1",
-    "tsx": "^4.21.0",
+    "tsx": "^4.22.4",
     "typescript": "^5.9.3",
-    "vitest": "^4.1.2"
+    "vitest": "^4.1.8"
   },
   "peerDependencies": {
     "@commercelayer/sdk": "^6 || ^7"

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "vitest": "^4.1.8"
   },
   "peerDependencies": {
-    "@commercelayer/sdk": "^6 || ^7"
+    "@commercelayer/sdk": "^7.11.0"
   },
   "repository": "github:commercelayer/commercelayer-sdk-utils",
   "publishConfig": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,23 +12,23 @@ importers:
         specifier: 2.4.8
         version: 2.4.8
       '@commercelayer/js-auth':
-        specifier: ^7.3.0
-        version: 7.3.0
+        specifier: ^7.4.2
+        version: 7.4.2
       '@commercelayer/sdk':
-        specifier: ^7.10.0
-        version: 7.10.0
+        specifier: ^7.11.0
+        version: 7.11.0
       '@semantic-release/changelog':
         specifier: ^6.0.3
-        version: 6.0.3(semantic-release@25.0.3(typescript@5.9.3))
+        version: 6.0.3(semantic-release@25.0.5(typescript@5.9.3))
       '@semantic-release/git':
         specifier: ^10.0.1
-        version: 10.0.1(semantic-release@25.0.3(typescript@5.9.3))
+        version: 10.0.1(semantic-release@25.0.5(typescript@5.9.3))
       '@types/node':
-        specifier: ^24.12.0
-        version: 24.12.0
+        specifier: ^24.13.2
+        version: 24.13.2
       '@vitest/coverage-v8':
-        specifier: ^4.1.2
-        version: 4.1.2(vitest@4.1.2(@types/node@24.12.0)(vite@7.3.1(@types/node@24.12.0)(tsx@4.21.0)))
+        specifier: ^4.1.8
+        version: 4.1.8(vitest@4.1.8)
       conventional-changelog-conventionalcommits:
         specifier: ^9.3.1
         version: 9.3.1
@@ -39,54 +39,54 @@ importers:
         specifier: ^0.1.3
         version: 0.1.3
       semantic-release:
-        specifier: ^25.0.3
-        version: 25.0.3(typescript@5.9.3)
+        specifier: ^25.0.5
+        version: 25.0.5(typescript@5.9.3)
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(postcss@8.5.8)(tsx@4.21.0)(typescript@5.9.3)
+        version: 8.5.1(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)
       tsx:
-        specifier: ^4.21.0
-        version: 4.21.0
+        specifier: ^4.22.4
+        version: 4.22.4
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
       vitest:
-        specifier: ^4.1.2
-        version: 4.1.2(@types/node@24.12.0)(vite@7.3.1(@types/node@24.12.0)(tsx@4.21.0))
+        specifier: ^4.1.8
+        version: 4.1.8(@types/node@24.13.2)(@vitest/coverage-v8@4.1.8)(vite@7.3.1(@types/node@24.13.2)(tsx@4.22.4))
 
 packages:
 
-  '@actions/core@3.0.0':
-    resolution: {integrity: sha512-zYt6cz+ivnTmiT/ksRVriMBOiuoUpDCJJlZ5KPl2/FRdvwU3f7MPh9qftvbkXJThragzUZieit2nyHUyw53Seg==}
+  '@actions/core@3.0.1':
+    resolution: {integrity: sha512-a6d/Nwahm9fliVGRhdhofo40HjHQasUPusmc7vBfyky+7Z+P2A1J68zyFVaNcEclc/Se+eO595oAr5nwEIoIUA==}
 
   '@actions/exec@3.0.0':
     resolution: {integrity: sha512-6xH/puSoNBXb72VPlZVm7vQ+svQpFyA96qdDBvhB8eNZOE8LtPf9L4oAsfzK/crCL8YZ+19fKYVnM63Sl+Xzlw==}
 
-  '@actions/http-client@4.0.0':
-    resolution: {integrity: sha512-QuwPsgVMsD6qaPD57GLZi9sqzAZCtiJT8kVBCDpLtxhL5MydQ4gS+DrejtZZPdIYyB1e95uCK9Luyds7ybHI3g==}
+  '@actions/http-client@4.0.1':
+    resolution: {integrity: sha512-+Nvd1ImaOZBSoPbsUtEhv+1z99H12xzncCkz0a3RuehINE81FZSe2QTj3uvAPTcJX/SCzUQHQ0D1GrPMbrPitg==}
 
   '@actions/io@3.0.2':
     resolution: {integrity: sha512-nRBchcMM+QK1pdjO7/idu86rbJI5YHUKCvKs0KxnSYbVe3F51UfGxuZX4Qy/fWlp6l7gWFwIkrOzN+oUK03kfw==}
 
-  '@babel/code-frame@7.29.0':
-    resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
+  '@babel/code-frame@7.29.7':
+    resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-string-parser@7.27.1':
-    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
+  '@babel/helper-string-parser@7.29.7':
+    resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-validator-identifier@7.28.5':
-    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/parser@7.29.2':
-    resolution: {integrity: sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==}
+  '@babel/parser@7.29.7':
+    resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
-  '@babel/types@7.29.0':
-    resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
+  '@babel/types@7.29.7':
+    resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
     engines: {node: '>=6.9.0'}
 
   '@bcoe/v8-coverage@1.0.2':
@@ -154,166 +154,322 @@ packages:
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
     engines: {node: '>=0.1.90'}
 
-  '@commercelayer/js-auth@7.3.0':
-    resolution: {integrity: sha512-o4HkMHqXqhPJ3gOA/61Na9T0ssLluV/SQEPtnb/N9/WpbiemEW43M1h/Iuc0/H8fSThqWe3Crt5HwGT5qAz6vQ==}
+  '@commercelayer/js-auth@7.4.2':
+    resolution: {integrity: sha512-ifRcoAL1R7o5AU5w4bgmSnNMEWXDc11A+yZwAAZMEkAYrrsaud1X/3xmgY1e0yIXK8AAdIiqfW/Rm/4DdWwAQA==}
     engines: {node: '>=20.0.0'}
 
-  '@commercelayer/sdk@7.10.0':
-    resolution: {integrity: sha512-KmC3SzOTB/9E6L4Ka7QMsRgDtAZVsdY+fCp35wZyIOQvI+AFNhE+G1VTIF1xUxkuE4fmkWWPZCGPbkLlHbbZ7A==}
+  '@commercelayer/sdk@7.11.0':
+    resolution: {integrity: sha512-ICphKAsAepqoUdC48PcwQ2QSnTNC25UZdMHHNyHENqXL795HJ0+e/R7EHUIdTW9xoHQiW5WYTQCdmJRjrOX0/g==}
     engines: {node: '>=20'}
 
-  '@esbuild/aix-ppc64@0.27.5':
-    resolution: {integrity: sha512-nGsF/4C7uzUj+Nj/4J+Zt0bYQ6bz33Phz8Lb2N80Mti1HjGclTJdXZ+9APC4kLvONbjxN1zfvYNd8FEcbBK/MQ==}
+  '@esbuild/aix-ppc64@0.27.7':
+    resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/android-arm64@0.27.5':
-    resolution: {integrity: sha512-Oeghq+XFgh1pUGd1YKs4DDoxzxkoUkvko+T/IVKwlghKLvvjbGFB3ek8VEDBmNvqhwuL0CQS3cExdzpmUyIrgA==}
+  '@esbuild/aix-ppc64@0.28.0':
+    resolution: {integrity: sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.27.7':
+    resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
 
-  '@esbuild/android-arm@0.27.5':
-    resolution: {integrity: sha512-Cv781jd0Rfj/paoNrul1/r4G0HLvuFKYh7C9uHZ2Pl8YXstzvCyyeWENTFR9qFnRzNMCjXmsulZuvosDg10Mog==}
+  '@esbuild/android-arm64@0.28.0':
+    resolution: {integrity: sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.27.7':
+    resolution: {integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-x64@0.27.5':
-    resolution: {integrity: sha512-nQD7lspbzerlmtNOxYMFAGmhxgzn8Z7m9jgFkh6kpkjsAhZee1w8tJW3ZlW+N9iRePz0oPUDrYrXidCPSImD0Q==}
+  '@esbuild/android-arm@0.28.0':
+    resolution: {integrity: sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.7':
+    resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
-  '@esbuild/darwin-arm64@0.27.5':
-    resolution: {integrity: sha512-I+Ya/MgC6rr8oRWGRDF3BXDfP8K1BVUggHqN6VI2lUZLdDi1IM1v2cy0e3lCPbP+pVcK3Tv8cgUhHse1kaNZZw==}
+  '@esbuild/android-x64@0.28.0':
+    resolution: {integrity: sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.27.7':
+    resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [darwin]
 
-  '@esbuild/darwin-x64@0.27.5':
-    resolution: {integrity: sha512-MCjQUtC8wWJn/pIPM7vQaO69BFgwPD1jriEdqwTCKzWjGgkMbcg+M5HzrOhPhuYe1AJjXlHmD142KQf+jnYj8A==}
+  '@esbuild/darwin-arm64@0.28.0':
+    resolution: {integrity: sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.7':
+    resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/freebsd-arm64@0.27.5':
-    resolution: {integrity: sha512-X6xVS+goSH0UelYXnuf4GHLwpOdc8rgK/zai+dKzBMnncw7BTQIwquOodE7EKvY2UVUetSqyAfyZC1D+oqLQtg==}
+  '@esbuild/darwin-x64@0.28.0':
+    resolution: {integrity: sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.27.7':
+    resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [freebsd]
 
-  '@esbuild/freebsd-x64@0.27.5':
-    resolution: {integrity: sha512-233X1FGo3a8x1ekLB6XT69LfZ83vqz+9z3TSEQCTYfMNY880A97nr81KbPcAMl9rmOFp11wO0dP+eB18KU/Ucg==}
+  '@esbuild/freebsd-arm64@0.28.0':
+    resolution: {integrity: sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.7':
+    resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/linux-arm64@0.27.5':
-    resolution: {integrity: sha512-euKkilsNOv7x/M1NKsx5znyprbpsRFIzTV6lWziqJch7yWYayfLtZzDxDTl+LSQDJYAjd9TVb/Kt5UKIrj2e4A==}
+  '@esbuild/freebsd-x64@0.28.0':
+    resolution: {integrity: sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.27.7':
+    resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [linux]
 
-  '@esbuild/linux-arm@0.27.5':
-    resolution: {integrity: sha512-0wkVrYHG4sdCCN/bcwQ7yYMXACkaHc3UFeaEOwSVW6e5RycMageYAFv+JS2bKLwHyeKVUvtoVH+5/RHq0fgeFw==}
+  '@esbuild/linux-arm64@0.28.0':
+    resolution: {integrity: sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.7':
+    resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.27.5':
-    resolution: {integrity: sha512-hVRQX4+P3MS36NxOy24v/Cdsimy/5HYePw+tmPqnNN1fxV0bPrFWR6TMqwXPwoTM2VzbkA+4lbHWUKDd5ZDA/w==}
+  '@esbuild/linux-arm@0.28.0':
+    resolution: {integrity: sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.27.7':
+    resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [linux]
 
-  '@esbuild/linux-loong64@0.27.5':
-    resolution: {integrity: sha512-mKqqRuOPALI8nDzhOBmIS0INvZOOFGGg5n1osGIXAx8oersceEbKd4t1ACNTHM3sJBXGFAlEgqM+svzjPot+ZQ==}
+  '@esbuild/linux-ia32@0.28.0':
+    resolution: {integrity: sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.7':
+    resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.27.5':
-    resolution: {integrity: sha512-EE/QXH9IyaAj1qeuIV5+/GZkBTipgGO782Ff7Um3vPS9cvLhJJeATy4Ggxikz2inZ46KByamMn6GqtqyVjhenA==}
+  '@esbuild/linux-loong64@0.28.0':
+    resolution: {integrity: sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.27.7':
+    resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
     engines: {node: '>=18'}
     cpu: [mips64el]
     os: [linux]
 
-  '@esbuild/linux-ppc64@0.27.5':
-    resolution: {integrity: sha512-0V2iF1RGxBf1b7/BjurA5jfkl7PtySjom1r6xOK2q9KWw/XCpAdtB6KNMO+9xx69yYfSCRR9FE0TyKfHA2eQMw==}
+  '@esbuild/linux-mips64el@0.28.0':
+    resolution: {integrity: sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.7':
+    resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.27.5':
-    resolution: {integrity: sha512-rYxThBx6G9HN6tFNuvB/vykeLi4VDsm5hE5pVwzqbAjZEARQrWu3noZSfbEnPZ/CRXP3271GyFk/49up2W190g==}
+  '@esbuild/linux-ppc64@0.28.0':
+    resolution: {integrity: sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.27.7':
+    resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
     engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
 
-  '@esbuild/linux-s390x@0.27.5':
-    resolution: {integrity: sha512-uEP2q/4qgd8goEUc4QIdU/1P2NmEtZ/zX5u3OpLlCGhJIuBIv0s0wr7TB2nBrd3/A5XIdEkkS5ZLF0ULuvaaYQ==}
+  '@esbuild/linux-riscv64@0.28.0':
+    resolution: {integrity: sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.7':
+    resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
 
-  '@esbuild/linux-x64@0.27.5':
-    resolution: {integrity: sha512-+Gq47Wqq6PLOOZuBzVSII2//9yyHNKZLuwfzCemqexqOQCSz0zy0O26kIzyp9EMNMK+nZ0tFHBZrCeVUuMs/ew==}
+  '@esbuild/linux-s390x@0.28.0':
+    resolution: {integrity: sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.27.7':
+    resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/netbsd-arm64@0.27.5':
-    resolution: {integrity: sha512-3F/5EG8VHfN/I+W5cO1/SV2H9Q/5r7vcHabMnBqhHK2lTWOh3F8vixNzo8lqxrlmBtZVFpW8pmITHnq54+Tq4g==}
+  '@esbuild/linux-x64@0.28.0':
+    resolution: {integrity: sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
 
-  '@esbuild/netbsd-x64@0.27.5':
-    resolution: {integrity: sha512-28t+Sj3CPN8vkMOlZotOmDgilQwVvxWZl7b8rxpn73Tt/gCnvrHxQUMng4uu3itdFvrtba/1nHejvxqz8xgEMA==}
+  '@esbuild/netbsd-arm64@0.28.0':
+    resolution: {integrity: sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.7':
+    resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/openbsd-arm64@0.27.5':
-    resolution: {integrity: sha512-Doz/hKtiuVAi9hMsBMpwBANhIZc8l238U2Onko3t2xUp8xtM0ZKdDYHMnm/qPFVthY8KtxkXaocwmMh6VolzMA==}
+  '@esbuild/netbsd-x64@0.28.0':
+    resolution: {integrity: sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
 
-  '@esbuild/openbsd-x64@0.27.5':
-    resolution: {integrity: sha512-WfGVaa1oz5A7+ZFPkERIbIhKT4olvGl1tyzTRaB5yoZRLqC0KwaO95FeZtOdQj/oKkjW57KcVF944m62/0GYtA==}
+  '@esbuild/openbsd-arm64@0.28.0':
+    resolution: {integrity: sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.27.7':
+    resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
 
-  '@esbuild/openharmony-arm64@0.27.5':
-    resolution: {integrity: sha512-Xh+VRuh6OMh3uJ0JkCjI57l+DVe7VRGBYymen8rFPnTVgATBwA6nmToxM2OwTlSvrnWpPKkrQUj93+K9huYC6A==}
+  '@esbuild/openbsd-x64@0.28.0':
+    resolution: {integrity: sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
 
-  '@esbuild/sunos-x64@0.27.5':
-    resolution: {integrity: sha512-aC1gpJkkaUADHuAdQfuVTnqVUTLqqUNhAvEwHwVWcnVVZvNlDPGA0UveZsfXJJ9T6k9Po4eHi3c02gbdwO3g6w==}
+  '@esbuild/openharmony-arm64@0.28.0':
+    resolution: {integrity: sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.27.7':
+    resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
 
-  '@esbuild/win32-arm64@0.27.5':
-    resolution: {integrity: sha512-0UNx2aavV0fk6UpZcwXFLztA2r/k9jTUa7OW7SAea1VYUhkug99MW1uZeXEnPn5+cHOd0n8myQay6TlFnBR07w==}
+  '@esbuild/sunos-x64@0.28.0':
+    resolution: {integrity: sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.27.7':
+    resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.27.5':
-    resolution: {integrity: sha512-5nlJ3AeJWCTSzR7AEqVjT/faWyqKU86kCi1lLmxVqmNR+j4HrYdns+eTGjS/vmrzCIe8inGQckUadvS0+JkKdQ==}
+  '@esbuild/win32-arm64@0.28.0':
+    resolution: {integrity: sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.27.7':
+    resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [win32]
 
-  '@esbuild/win32-x64@0.27.5':
-    resolution: {integrity: sha512-PWypQR+d4FLfkhBIV+/kHsUELAnMpx1bRvvsn3p+/sAERbnCzFrtDRG2Xw5n+2zPxBK2+iaP+vetsRl4Ti7WgA==}
+  '@esbuild/win32-ia32@0.28.0':
+    resolution: {integrity: sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.7':
+    resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.0':
+    resolution: {integrity: sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -372,8 +528,8 @@ packages:
     resolution: {integrity: sha512-KMQIfq5sOPpkQYajXHwnhjCC0slzCNScLHs9JafXc4RAJI+9f+jNDlBNaIMTvazOPLgb4BnlhGJOTbnN0wIjPw==}
     engines: {node: '>= 20'}
 
-  '@octokit/request@10.0.8':
-    resolution: {integrity: sha512-SJZNwY9pur9Agf7l87ywFi14W+Hd9Jg6Ifivsd33+/bGUQIjNujdFiXII2/qSlN2ybqUHfp5xpekMEjIBTjlSw==}
+  '@octokit/request@10.0.10':
+    resolution: {integrity: sha512-KxNC2pTqqhszMNrf12ZRd4PonRgyJdsM4F/jySiddQK+DsRcfBtUvqn8t7UsyZhnRJHvX46OohDt5N3VqIWC2w==}
     engines: {node: '>= 20'}
 
   '@octokit/types@16.0.0':
@@ -391,141 +547,141 @@ packages:
     resolution: {integrity: sha512-h104Kh26rR8tm+a3Qkc5S4VLYint3FE48as7+/5oCEcKR2idC/pF1G6AhIXKI+eHPJa/3J9i5z0Al47IeGHPkA==}
     engines: {node: '>=12'}
 
-  '@rollup/rollup-android-arm-eabi@4.60.1':
-    resolution: {integrity: sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==}
+  '@rollup/rollup-android-arm-eabi@4.61.1':
+    resolution: {integrity: sha512-JnBB8MdXj45cajvTuO5FmPlvFVJRQgvrz1uSEl3NwqFnReAPGwb8EanbGi4z2nRaqLzjJSv5/JmycoTKlRZxHA==}
     cpu: [arm]
     os: [android]
 
-  '@rollup/rollup-android-arm64@4.60.1':
-    resolution: {integrity: sha512-YjG/EwIDvvYI1YvYbHvDz/BYHtkY4ygUIXHnTdLhG+hKIQFBiosfWiACWortsKPKU/+dUwQQCKQM3qrDe8c9BA==}
+  '@rollup/rollup-android-arm64@4.61.1':
+    resolution: {integrity: sha512-Jx2g7iSjw4AOT0HDPHM9RV3GNjRXwybWtSFZiZAYUTjUwjVrYIwq3kBf+LnhqJlzXFAqTAh2F7IGI+O568exPw==}
     cpu: [arm64]
     os: [android]
 
-  '@rollup/rollup-darwin-arm64@4.60.1':
-    resolution: {integrity: sha512-mjCpF7GmkRtSJwon+Rq1N8+pI+8l7w5g9Z3vWj4T7abguC4Czwi3Yu/pFaLvA3TTeMVjnu3ctigusqWUfjZzvw==}
+  '@rollup/rollup-darwin-arm64@4.61.1':
+    resolution: {integrity: sha512-0F1L/Z3Eqv8mT2n3dCpeO8GcTvHvVqkP5/t6DMsn0KzhYVcg+s7Ncl5DS8qjKYEeio6Az0Gt6nyBORay5qIlCA==}
     cpu: [arm64]
     os: [darwin]
 
-  '@rollup/rollup-darwin-x64@4.60.1':
-    resolution: {integrity: sha512-haZ7hJ1JT4e9hqkoT9R/19XW2QKqjfJVv+i5AGg57S+nLk9lQnJ1F/eZloRO3o9Scy9CM3wQ9l+dkXtcBgN5Ew==}
+  '@rollup/rollup-darwin-x64@4.61.1':
+    resolution: {integrity: sha512-qLttcH871ujY4YcVfUSShhOw+CsoTatYz8gRbHO7Bb92QH059/P0y5do1KMs41fY0BpD2x4AJH/gID0zFiqVKQ==}
     cpu: [x64]
     os: [darwin]
 
-  '@rollup/rollup-freebsd-arm64@4.60.1':
-    resolution: {integrity: sha512-czw90wpQq3ZsAVBlinZjAYTKduOjTywlG7fEeWKUA7oCmpA8xdTkxZZlwNJKWqILlq0wehoZcJYfBvOyhPTQ6w==}
+  '@rollup/rollup-freebsd-arm64@4.61.1':
+    resolution: {integrity: sha512-fUI4RapGE0Oh3mb8mgfvC1O2nU1RpDZUKnDQm3xB1Ipg7C2wTs5Kstz7G2uWK99a8S2yTMq8/P4uycwNa0nJyw==}
     cpu: [arm64]
     os: [freebsd]
 
-  '@rollup/rollup-freebsd-x64@4.60.1':
-    resolution: {integrity: sha512-KVB2rqsxTHuBtfOeySEyzEOB7ltlB/ux38iu2rBQzkjbwRVlkhAGIEDiiYnO2kFOkJp+Z7pUXKyrRRFuFUKt+g==}
+  '@rollup/rollup-freebsd-x64@4.61.1':
+    resolution: {integrity: sha512-H5YrdvJaDtI/U9/emrD4b++xkvp3y/JvOe4rizHbxvkyMfRS/CiRYdji+Pl8D0brEaNFWUh1drQxgAGIl6Xudw==}
     cpu: [x64]
     os: [freebsd]
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.60.1':
-    resolution: {integrity: sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==}
+  '@rollup/rollup-linux-arm-gnueabihf@4.61.1':
+    resolution: {integrity: sha512-Q8CBCCQtDFrYtXoeUXSrnFXKOnyUhx6bz+SkL6A0E7V8kAiCJ5pamq1WtbfpVGhR5TSpXY6ak3avmDc5fHTyJA==}
     cpu: [arm]
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-arm-musleabihf@4.60.1':
-    resolution: {integrity: sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==}
+  '@rollup/rollup-linux-arm-musleabihf@4.61.1':
+    resolution: {integrity: sha512-nwnhk1581l0FBVellGcVCAT0Oi06onEA3WB53sf01VO3I0UPBkMH9sXONYME2K0ovXcNayJfNtHfm6mpJElatQ==}
     cpu: [arm]
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-arm64-gnu@4.60.1':
-    resolution: {integrity: sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==}
+  '@rollup/rollup-linux-arm64-gnu@4.61.1':
+    resolution: {integrity: sha512-x5Xr49hwt3hdW75UOZm3395YwwzPyauktslv29KpWL/T+vVAzoT3azLcTWv0eMciBNrx+DYjH4paehHoLpPvpg==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-arm64-musl@4.60.1':
-    resolution: {integrity: sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==}
+  '@rollup/rollup-linux-arm64-musl@4.61.1':
+    resolution: {integrity: sha512-unMS3H73DpaoPyyEVPjGKleM/s0mkmsauTENpw4INQY8y4+IuLNjkueQ5QCtC0D3N38Y38yhAU8OoZ20S2Tm6w==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-loong64-gnu@4.60.1':
-    resolution: {integrity: sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==}
+  '@rollup/rollup-linux-loong64-gnu@4.61.1':
+    resolution: {integrity: sha512-zNZzGRnAhwjFEYmvphJRV5XaQGjs62cCmeYYHUT//NbvEnHauw+I85nGG+SiVg5ld4GX8D1IbKIX+ozITQnhMQ==}
     cpu: [loong64]
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-loong64-musl@4.60.1':
-    resolution: {integrity: sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==}
+  '@rollup/rollup-linux-loong64-musl@4.61.1':
+    resolution: {integrity: sha512-LdpWGL8X209B2SIvWjqlc8VZgM6PKfontSerGepuldQmHYrAOtnMCXeJkxXGbC+PPZVOuu5czJo7fNV6aeW8rQ==}
     cpu: [loong64]
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-ppc64-gnu@4.60.1':
-    resolution: {integrity: sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==}
+  '@rollup/rollup-linux-ppc64-gnu@4.61.1':
+    resolution: {integrity: sha512-EC5kTtNaNGOmbMGqar8dvJy6y/hg99GAwjfBz++pxZhQATXGcRjd6c5en5wcbru0vkRmiMGsQKdMJOOf6sza4g==}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-ppc64-musl@4.60.1':
-    resolution: {integrity: sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==}
+  '@rollup/rollup-linux-ppc64-musl@4.61.1':
+    resolution: {integrity: sha512-8hiwp6D4acEcNK78I4rP0/XtS1sknWIAMJBPdR4l6zUtyTm5KiTDr5bXmWt4foY7nAN7AThDHgkLIEZOWKbzWw==}
     cpu: [ppc64]
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-riscv64-gnu@4.60.1':
-    resolution: {integrity: sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==}
+  '@rollup/rollup-linux-riscv64-gnu@4.61.1':
+    resolution: {integrity: sha512-10dh/h/BqA7DuMPWSxkR8uks18FRwnwOEqr5zOTEl+NOwP/OMzKX8OFR/Of9xxDA7D5qef1Nzar5WDD2kCCr1g==}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-riscv64-musl@4.60.1':
-    resolution: {integrity: sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==}
+  '@rollup/rollup-linux-riscv64-musl@4.61.1':
+    resolution: {integrity: sha512-YKJ5lg35DP17gcAOggnihe+APw9HLyj1Xn7gsmGumBJAUDa6NGXNixJzmkWLhcK9TOuuyQjdamzvJefkO7qHZQ==}
     cpu: [riscv64]
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-s390x-gnu@4.60.1':
-    resolution: {integrity: sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==}
+  '@rollup/rollup-linux-s390x-gnu@4.61.1':
+    resolution: {integrity: sha512-Mlil5G2Jj6a7B3LWGctg+XPL9vdXYuzCtNXfxOQ0nPjc2m6ueUktocPGH9bnAM0bNRKb/bAWTujUU7IJQdQA+g==}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-x64-gnu@4.60.1':
-    resolution: {integrity: sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==}
+  '@rollup/rollup-linux-x64-gnu@4.61.1':
+    resolution: {integrity: sha512-bVWIOIk6pV01p4CdUbPP7CJ/434z+OooYjDuFcR+44N35YvKUC66G8MGnvcWx5mWKW3g61J+t74l3Kj15Kwn2Q==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-x64-musl@4.60.1':
-    resolution: {integrity: sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==}
+  '@rollup/rollup-linux-x64-musl@4.61.1':
+    resolution: {integrity: sha512-qy5pBvZbqNFheBz61R1rzsezjm0J7O2oNGoWtGoY89SZYLUfxAJTBAqDChqAIdB4rCiIbi9nF7yZ83GnNiLwSw==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-openbsd-x64@4.60.1':
-    resolution: {integrity: sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==}
+  '@rollup/rollup-openbsd-x64@4.61.1':
+    resolution: {integrity: sha512-E83TXjI4zm0+5f2qO+UOudaCYIhYwpJ5jq6YCZNIZ+6CbfhKrkAGezeiASBL9ElxAxFsRS9ZhESv8mfnj6TKeg==}
     cpu: [x64]
     os: [openbsd]
 
-  '@rollup/rollup-openharmony-arm64@4.60.1':
-    resolution: {integrity: sha512-4Cv23ZrONRbNtbZa37mLSueXUCtN7MXccChtKpUnQNgF010rjrjfHx3QxkS2PI7LqGT5xXyYs1a7LbzAwT0iCA==}
+  '@rollup/rollup-openharmony-arm64@4.61.1':
+    resolution: {integrity: sha512-fbWnKqVkjrJN38vNe3ahkbk6iejS/3b0Nt7EEtPpE6RBacZcGXNKbzfHN3GUUlXOPghUg0j6XUGrtjX9z1sIvA==}
     cpu: [arm64]
     os: [openharmony]
 
-  '@rollup/rollup-win32-arm64-msvc@4.60.1':
-    resolution: {integrity: sha512-i1okWYkA4FJICtr7KpYzFpRTHgy5jdDbZiWfvny21iIKky5YExiDXP+zbXzm3dUcFpkEeYNHgQ5fuG236JPq0g==}
+  '@rollup/rollup-win32-arm64-msvc@4.61.1':
+    resolution: {integrity: sha512-ArMl38iVAbk0New1ogihQNY6iphLi4ZaRsa037gUzv5yeKPY8TD3Dmy4x2RNC1VztU/uqm+G+/RwFrSka3Oy2g==}
     cpu: [arm64]
     os: [win32]
 
-  '@rollup/rollup-win32-ia32-msvc@4.60.1':
-    resolution: {integrity: sha512-u09m3CuwLzShA0EYKMNiFgcjjzwqtUMLmuCJLeZWjjOYA3IT2Di09KaxGBTP9xVztWyIWjVdsB2E9goMjZvTQg==}
+  '@rollup/rollup-win32-ia32-msvc@4.61.1':
+    resolution: {integrity: sha512-0mYtjHS9ucAbcATycCNK9IGBk/cCe/ma7EmSLGZdsxnOA8cjRIyU04wDpVAD9NiOfLUR9KTxdiO53uOkherqjQ==}
     cpu: [ia32]
     os: [win32]
 
-  '@rollup/rollup-win32-x64-gnu@4.60.1':
-    resolution: {integrity: sha512-k+600V9Zl1CM7eZxJgMyTUzmrmhB/0XZnF4pRypKAlAgxmedUA+1v9R+XOFv56W4SlHEzfeMtzujLJD22Uz5zg==}
+  '@rollup/rollup-win32-x64-gnu@4.61.1':
+    resolution: {integrity: sha512-gK1iCEPfpoSG9wfBihXxvBMi8ZfcWffYkEsC/Eih+iFENTaewvNcrEQ69lIOWYO5pePHKLHHO7nq5AILGO/HQQ==}
     cpu: [x64]
     os: [win32]
 
-  '@rollup/rollup-win32-x64-msvc@4.60.1':
-    resolution: {integrity: sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ==}
+  '@rollup/rollup-win32-x64-msvc@4.61.1':
+    resolution: {integrity: sha512-X+zaP2x+j4RXGfbp/seSoRHWnPxzApilDszisZxbYH5C/jTxFhCtDNdPGZb9lJyYPs24wGxruPF7Y+sIXt9Gzw==}
     cpu: [x64]
     os: [win32]
 
@@ -558,8 +714,8 @@ packages:
     peerDependencies:
       semantic-release: '>=18.0.0'
 
-  '@semantic-release/github@12.0.6':
-    resolution: {integrity: sha512-aYYFkwHW3c6YtHwQF0t0+lAjlU+87NFOZuH2CvWFD0Ylivc7MwhZMiHOJ0FMpIgPpCVib/VUAcOwvrW0KnxQtA==}
+  '@semantic-release/github@12.0.8':
+    resolution: {integrity: sha512-tej5AAgK5X9wHRoDmYhecMXEHEkFeGOY1XsEblKxu8pIQwahzf1STYyr7iPU6Lpbg6C5I3N2w/ocXrBo+L7jhw==}
     engines: {node: ^22.14.0 || >= 24.10.0}
     peerDependencies:
       semantic-release: '>=24.1.0'
@@ -570,8 +726,8 @@ packages:
     peerDependencies:
       semantic-release: '>=20.1.0'
 
-  '@semantic-release/release-notes-generator@14.1.0':
-    resolution: {integrity: sha512-CcyDRk7xq+ON/20YNR+1I/jP7BYKICr1uKd1HHpROSnnTdGqOTburi4jcRiTYz0cpfhxSloQO3cGhnoot7IEkA==}
+  '@semantic-release/release-notes-generator@14.1.1':
+    resolution: {integrity: sha512-Pbd2e2XRMUD0OxehHpgd5/YghsE76cddkRHSoDvKLK+OCy4Ewxn49rWR631MEUU01lgwF/uyVXvbnVuu6+Z6VA==}
     engines: {node: '>=20.8.1'}
     peerDependencies:
       semantic-release: '>=20.1.0'
@@ -597,29 +753,29 @@ packages:
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
-  '@types/estree@1.0.8':
-    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
-  '@types/node@24.12.0':
-    resolution: {integrity: sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ==}
+  '@types/node@24.13.2':
+    resolution: {integrity: sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==}
 
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
 
-  '@vitest/coverage-v8@4.1.2':
-    resolution: {integrity: sha512-sPK//PHO+kAkScb8XITeB1bf7fsk85Km7+rt4eeuRR3VS1/crD47cmV5wicisJmjNdfeokTZwjMk4Mj2d58Mgg==}
+  '@vitest/coverage-v8@4.1.8':
+    resolution: {integrity: sha512-lt3kovsyHwYe00wq4D1ti0Z974fWj4NLp6siqiyEufUpyFwK9Yhi7rBhac9JL5aA0zoMrJqc4vYPZRUnI7l7nw==}
     peerDependencies:
-      '@vitest/browser': 4.1.2
-      vitest: 4.1.2
+      '@vitest/browser': 4.1.8
+      vitest: 4.1.8
     peerDependenciesMeta:
       '@vitest/browser':
         optional: true
 
-  '@vitest/expect@4.1.2':
-    resolution: {integrity: sha512-gbu+7B0YgUJ2nkdsRJrFFW6X7NTP44WlhiclHniUhxADQJH5Szt9mZ9hWnJPJ8YwOK5zUOSSlSvyzRf0u1DSBQ==}
+  '@vitest/expect@4.1.8':
+    resolution: {integrity: sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==}
 
-  '@vitest/mocker@4.1.2':
-    resolution: {integrity: sha512-Ize4iQtEALHDttPRCmN+FKqOl2vxTiNUhzobQFFt/BM1lRUTG7zRCLOykG/6Vo4E4hnUdfVLo5/eqKPukcWW7Q==}
+  '@vitest/mocker@4.1.8':
+    resolution: {integrity: sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==}
     peerDependencies:
       msw: ^2.4.9
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -629,29 +785,29 @@ packages:
       vite:
         optional: true
 
-  '@vitest/pretty-format@4.1.2':
-    resolution: {integrity: sha512-dwQga8aejqeuB+TvXCMzSQemvV9hNEtDDpgUKDzOmNQayl2OG241PSWeJwKRH3CiC+sESrmoFd49rfnq7T4RnA==}
+  '@vitest/pretty-format@4.1.8':
+    resolution: {integrity: sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==}
 
-  '@vitest/runner@4.1.2':
-    resolution: {integrity: sha512-Gr+FQan34CdiYAwpGJmQG8PgkyFVmARK8/xSijia3eTFgVfpcpztWLuP6FttGNfPLJhaZVP/euvujeNYar36OQ==}
+  '@vitest/runner@4.1.8':
+    resolution: {integrity: sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==}
 
-  '@vitest/snapshot@4.1.2':
-    resolution: {integrity: sha512-g7yfUmxYS4mNxk31qbOYsSt2F4m1E02LFqO53Xpzg3zKMhLAPZAjjfyl9e6z7HrW6LvUdTwAQR3HHfLjpko16A==}
+  '@vitest/snapshot@4.1.8':
+    resolution: {integrity: sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==}
 
-  '@vitest/spy@4.1.2':
-    resolution: {integrity: sha512-DU4fBnbVCJGNBwVA6xSToNXrkZNSiw59H8tcuUspVMsBDBST4nfvsPsEHDHGtWRRnqBERBQu7TrTKskmjqTXKA==}
+  '@vitest/spy@4.1.8':
+    resolution: {integrity: sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==}
 
-  '@vitest/utils@4.1.2':
-    resolution: {integrity: sha512-xw2/TiX82lQHA06cgbqRKFb5lCAy3axQ4H4SoUFhUsg+wztiet+co86IAMDtF6Vm1hc7J6j09oh/rgDn+JdKIQ==}
+  '@vitest/utils@4.1.8':
+    resolution: {integrity: sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==}
 
   acorn@8.16.0:
     resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
     engines: {node: '>=0.4.0'}
     hasBin: true
 
-  agent-base@7.1.4:
-    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
-    engines: {node: '>= 14'}
+  agent-base@9.0.0:
+    resolution: {integrity: sha512-TQf59BsZnytt8GdJKLPfUZ54g/iaUL2OWDSFCCvMOhsHduDQxO8xC4PNeyIkVcA5KwL2phPSv0douC0fgWzmnA==}
+    engines: {node: '>= 20'}
 
   aggregate-error@3.1.0:
     resolution: {integrity: sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==}
@@ -701,8 +857,8 @@ packages:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
-  ast-v8-to-istanbul@1.0.0:
-    resolution: {integrity: sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==}
+  ast-v8-to-istanbul@1.0.4:
+    resolution: {integrity: sha512-0bC0/4bTSrnwdhU3IsZDwEdojvuPrSg59OYZfKsLRtJZ0u8VBx9DebfqqG8bRdCC0I7vjgxmPi41P0lpkhJHtA==}
 
   before-after-hook@4.0.0:
     resolution: {integrity: sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==}
@@ -806,6 +962,10 @@ packages:
     resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
     engines: {node: ^14.18.0 || >=16.10.0}
 
+  content-type@2.0.0:
+    resolution: {integrity: sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==}
+    engines: {node: '>=18'}
+
   conventional-changelog-angular@8.3.1:
     resolution: {integrity: sha512-6gfI3otXK5Ph5DfCOI1dblr+kN3FAm5a97hYoQkqNZxOaYa5WKfXH+AnpsmS+iUH2mgVC2Cg2Qw9m5OKcmNrIg==}
     engines: {node: '>=18'}
@@ -838,8 +998,8 @@ packages:
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
 
-  cosmiconfig@9.0.1:
-    resolution: {integrity: sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==}
+  cosmiconfig@9.0.2:
+    resolution: {integrity: sha512-gtTZxTDau1wL7Y7zifc2dd8jHSK/k6BTx/2Xp/BpdlAdnlYWFVt7qhJqgwi7637yRwRQ3qL4ZidbB4I8tA5VOg==}
     engines: {node: '>=14'}
     peerDependencies:
       typescript: '>=4.9.5'
@@ -907,11 +1067,16 @@ packages:
   error-ex@1.3.4:
     resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
 
-  es-module-lexer@2.0.0:
-    resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
+  es-module-lexer@2.1.0:
+    resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
 
-  esbuild@0.27.5:
-    resolution: {integrity: sha512-zdQoHBjuDqKsvV5OPaWansOwfSQ0Js+Uj9J85TBvj3bFW1JjWTSULMRwdQAc8qMeIScbClxeMK0jlrtB9linhA==}
+  esbuild@0.27.7:
+    resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  esbuild@0.28.0:
+    resolution: {integrity: sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -945,9 +1110,6 @@ packages:
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
-
-  fast-content-type-parse@3.0.0:
-    resolution: {integrity: sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -985,11 +1147,8 @@ packages:
   fix-dts-default-cjs-exports@1.0.1:
     resolution: {integrity: sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==}
 
-  from2@2.3.0:
-    resolution: {integrity: sha512-OMcX/4IC/uqEPVgGeyfN22LJk6AZrMkRZHxcHBMBvHScDGgwTm2GT2Wkgtocyd3JfZffjj2kYUDXXII0Fk9W0g==}
-
-  fs-extra@11.3.4:
-    resolution: {integrity: sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==}
+  fs-extra@11.3.5:
+    resolution: {integrity: sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==}
     engines: {node: '>=14.14'}
 
   fsevents@2.3.3:
@@ -1005,17 +1164,13 @@ packages:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
 
-  get-east-asian-width@1.5.0:
-    resolution: {integrity: sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==}
+  get-east-asian-width@1.6.0:
+    resolution: {integrity: sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==}
     engines: {node: '>=18'}
 
   get-stream@6.0.1:
     resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
     engines: {node: '>=10'}
-
-  get-stream@7.0.1:
-    resolution: {integrity: sha512-3M8C1EOFN6r8AMUhwUAACIoXZJEOufDU5+0gFFN5uNs6XYOralD2Pqkl7m046va6x77FwposWXbAhPPIOus7mQ==}
-    engines: {node: '>=16'}
 
   get-stream@8.0.1:
     resolution: {integrity: sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==}
@@ -1024,9 +1179,6 @@ packages:
   get-stream@9.0.1:
     resolution: {integrity: sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==}
     engines: {node: '>=18'}
-
-  get-tsconfig@4.13.7:
-    resolution: {integrity: sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==}
 
   git-log-parser@1.2.1:
     resolution: {integrity: sha512-PI+sPDvHXNPl5WNOErAK05s3j0lgwUzMN6o8cyQrDaKfT3qd7TmNJKeXX+SknI5I0QhG5fVPAEwSY4tRGDtYoQ==}
@@ -1061,20 +1213,20 @@ packages:
     resolution: {integrity: sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==}
     engines: {node: ^16.14.0 || >=18.0.0}
 
-  hosted-git-info@9.0.2:
-    resolution: {integrity: sha512-M422h7o/BR3rmCQ8UHi7cyyMqKltdP9Uo+J2fXK+RSAY+wTcKOIRyhTuKv4qn+DJf3g+PL890AzId5KZpX+CBg==}
+  hosted-git-info@9.0.3:
+    resolution: {integrity: sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
-  http-proxy-agent@7.0.2:
-    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
-    engines: {node: '>= 14'}
+  http-proxy-agent@9.1.0:
+    resolution: {integrity: sha512-2NxoveTT58mjYT4n3RPTEfCZGLMbidoO8XEieXfpSYxu+PQJ1qpx4ypwH6N+uF9twBPIvRRgvkvW5HUTYWENig==}
+    engines: {node: '>= 20'}
 
-  https-proxy-agent@7.0.6:
-    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
-    engines: {node: '>= 14'}
+  https-proxy-agent@9.1.0:
+    resolution: {integrity: sha512-ag87y7cJJ9/3+GxFr8Oy4O5faDsGRGnBGsJj/YjOSsSx/5eadKLYTMPlzuR6obgoCDDm0abAAZitXXQkMOPSpA==}
+    engines: {node: '>= 20'}
 
   human-signals@2.1.0:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
@@ -1117,10 +1269,6 @@ packages:
   ini@1.3.8:
     resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
 
-  into-stream@7.0.0:
-    resolution: {integrity: sha512-2dYz766i9HprMBasCMvHMuazJ7u4WzhJwo5kb3iPSiW/iRYV6uPari3zHoqZlnuaR7V1bEiNMxikhp37rdBXbw==}
-    engines: {node: '>=12'}
-
   is-arrayish@0.2.1:
     resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
 
@@ -1162,8 +1310,8 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
-  issue-parser@7.0.1:
-    resolution: {integrity: sha512-3YZcUUR2Wt1WsapF+S/WiA2WmlW0cWAoPccMqne7AxEBhCdFeTPjfv/Axb8V2gyCgY3nRw+ksZ3xSUX+R47iAg==}
+  issue-parser@7.0.2:
+    resolution: {integrity: sha512-7atWPjhGEIX3JEtMrOYd8TKzboYlq+5sNbdl9POiLYOI14G5HZiQbZP0Xj5EZdrufQVXfJlpTV0hys0CuxwxZw==}
     engines: {node: ^18.17 || >=20.6.1}
 
   istanbul-lib-coverage@3.2.2:
@@ -1192,8 +1340,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.1.1:
-    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
+  js-yaml@4.2.0:
+    resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
     hasBin: true
 
   json-parse-better-errors@1.0.2:
@@ -1211,8 +1359,8 @@ packages:
   jsonapi-typescript@0.1.3:
     resolution: {integrity: sha512-uPcPS01GeM+4HIyn18s7l1yD2S3uLZy2TX1UkQffCM0bLb3TMwudXUyVXPHTMZ4vdZT8MqKqN2vjB5PogTAdFQ==}
 
-  jsonfile@6.2.0:
-    resolution: {integrity: sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==}
+  jsonfile@6.2.1:
+    resolution: {integrity: sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==}
 
   lilconfig@3.1.3:
     resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
@@ -1257,15 +1405,15 @@ packages:
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
-  lru-cache@11.2.7:
-    resolution: {integrity: sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==}
+  lru-cache@11.5.1:
+    resolution: {integrity: sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==}
     engines: {node: 20 || >=22}
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
-  magicast@0.5.2:
-    resolution: {integrity: sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==}
+  magicast@0.5.3:
+    resolution: {integrity: sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==}
 
   make-asynchronous@1.1.0:
     resolution: {integrity: sha512-ayF7iT+44LXdxJLTrTd3TLQpFDDvPCBxXxbv+pMUSuHA5Q8zyAfwkRP6aHHwNVFBUFWtxAHqwNJxF8vMZLAbVg==}
@@ -1322,8 +1470,8 @@ packages:
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
-  nanoid@3.3.11:
-    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+  nanoid@3.3.12:
+    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -1345,8 +1493,8 @@ packages:
     resolution: {integrity: sha512-RWk+PI433eESQ7ounYxIp67CYuVsS1uYSonX3kA6ps/3LWfjVQa/ptEg6Y3T6uAMq1mWpX9PQ+qx+QaHpsc7gQ==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
-  normalize-url@9.0.0:
-    resolution: {integrity: sha512-z9nC87iaZXXySbWWtTHfCFJyFvKaUAW6lODhikG7ILSbVgmwuFjUqkgnheHvAUcGedO29e2QGBRXMUD64aurqQ==}
+  normalize-url@9.0.1:
+    resolution: {integrity: sha512-ARftfC5HdUNu9jJeL8pHj8debUIHA2b91FizCoMzY4lG6dDX13jdvTK0TBe24IBDRf2HvJSzzwEPvmbkQWHRSg==}
     engines: {node: '>=20'}
 
   npm-run-path@4.0.1:
@@ -1361,8 +1509,8 @@ packages:
     resolution: {integrity: sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==}
     engines: {node: '>=18'}
 
-  npm@11.12.1:
-    resolution: {integrity: sha512-zcoUuF1kezGSAo0CqtvoLXX3mkRqzuqYdL6Y5tdo8g69NVV3CkjQ6ZBhBgB4d7vGkPcV6TcvLi3GRKPDFX+xTA==}
+  npm@11.16.0:
+    resolution: {integrity: sha512-A74XL8OxmcegZDMWPkWb5bEQppg8HdYwW3rBD2sPoS4UQHVajfaxBkqyzLeJ3wR0kZ+5xoTjItxXaF7eIXUsyw==}
     engines: {node: ^20.17.0 || >=22.9.0}
     hasBin: true
     bundledDependencies:
@@ -1436,8 +1584,9 @@ packages:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
 
-  obug@2.1.1:
-    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+  obug@2.1.2:
+    resolution: {integrity: sha512-AWGB9WFcRXOQs48Z/udjI5ZcZMHXwX8XPByNpOydgcGsDLIzjGizhoMWJyKAWze7AVW/2W1i+/gPX4YtKe5cyg==}
+    engines: {node: '>=12.20.0'}
 
   onetime@5.1.2:
     resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
@@ -1458,10 +1607,6 @@ packages:
   p-filter@4.1.0:
     resolution: {integrity: sha512-37/tPdZ3oJwHaS3gNJdenCDB3Tz26i9sjhnguBtvN0vYlRIiDNnvTWkuh+0hETV9rLPdJ3rlL3yVOYPIAnM8rw==}
     engines: {node: '>=18'}
-
-  p-is-promise@3.0.0:
-    resolution: {integrity: sha512-Wo8VsW4IRQSKVXsJCn7TomUaVtyfjVDn3nUP7kE967BQk0CwFpdbZs0X0uk5sW9mkBa9eNM7hCMaG93WUAwxYQ==}
-    engines: {node: '>=8'}
 
   p-limit@1.3.0:
     resolution: {integrity: sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==}
@@ -1583,8 +1728,8 @@ packages:
       yaml:
         optional: true
 
-  postcss@8.5.8:
-    resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
+  postcss@8.5.15:
+    resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
     engines: {node: ^10 || ^12 || >=14}
 
   pretty-ms@9.3.0:
@@ -1596,6 +1741,15 @@ packages:
 
   proto-list@1.2.4:
     resolution: {integrity: sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==}
+
+  proxy-agent-negotiate@1.1.0:
+    resolution: {integrity: sha512-N8IBcM3UgCVzz2L2Lqv8DVntDnnC8/hiV4nEDUPkqq72TPUgYWjQc+bdZlBPZK9LzPAvOY//gAt0S0DApoOXWQ==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      kerberos: ^2.0.0
+    peerDependenciesMeta:
+      kerberos:
+        optional: true
 
   rc@1.2.8:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
@@ -1640,19 +1794,16 @@ packages:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
     engines: {node: '>=8'}
 
-  resolve-pkg-maps@1.0.0:
-    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
-
-  rollup@4.60.1:
-    resolution: {integrity: sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==}
+  rollup@4.61.1:
+    resolution: {integrity: sha512-I4KW6iuRpuu2uHBLraZ1wNZe0DP7lnRha+VJ9tNaYVaVgKhW0aI3h4RYnoRPeql0flHm/Co55b7snEDcOfOJrA==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
   safe-buffer@5.1.2:
     resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
 
-  semantic-release@25.0.3:
-    resolution: {integrity: sha512-WRgl5GcypwramYX4HV+eQGzUbD7UUbljVmS+5G1uMwX/wLgYuJAxGeerXJDMO2xshng4+FXqCgyB5QfClV6WjA==}
+  semantic-release@25.0.5:
+    resolution: {integrity: sha512-mn61SUJwtM8ThrWn2WmgLVpwVJeG/hPSupua1psdMoufmwRIPyvRLkRkL0JDXkP67OntlLWUYnBnfVc8EDO3/g==}
     engines: {node: ^22.14.0 || >= 24.10.0}
     hasBin: true
 
@@ -1660,8 +1811,8 @@ packages:
     resolution: {integrity: sha512-hunMQrEy1T6Jr2uEVjrAIqjwWcQTgOAcIM52C8MY1EZSD3DDNft04XzvYKPqjED65bNVVko0YI38nYeEHCX3yw==}
     engines: {node: '>=12'}
 
-  semver@7.7.4:
-    resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
+  semver@7.8.4:
+    resolution: {integrity: sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -1724,8 +1875,8 @@ packages:
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
-  std-env@4.0.0:
-    resolution: {integrity: sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==}
+  std-env@4.1.0:
+    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
   stream-combiner2@1.1.1:
     resolution: {integrity: sha512-3PnJbYgS56AeWgtKF5jtJRT6uFJe56Z0Hc5Ngg/6sI6rIt8iiMBTa9cvdyFfpMQjaVHr8dusbNeFGIIonxOvKw==}
@@ -1822,12 +1973,12 @@ packages:
   tinyexec@0.3.2:
     resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
 
-  tinyexec@1.0.4:
-    resolution: {integrity: sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==}
+  tinyexec@1.2.4:
+    resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
     engines: {node: '>=18'}
 
-  tinyglobby@0.2.15:
-    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
 
   tinyrainbow@3.1.0:
@@ -1868,8 +2019,8 @@ packages:
       typescript:
         optional: true
 
-  tsx@4.21.0:
-    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
+  tsx@4.22.4:
+    resolution: {integrity: sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==}
     engines: {node: '>=18.0.0'}
     hasBin: true
 
@@ -1889,8 +2040,8 @@ packages:
     resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
     engines: {node: '>=16'}
 
-  type-fest@5.5.0:
-    resolution: {integrity: sha512-PlBfpQwiUvGViBNX84Yxwjsdhd1TUlXr6zjX7eoirtCPIr08NAmxwa+fcYBTeRQxHo9YC9wwF3m9i700sHma8g==}
+  type-fest@5.7.0:
+    resolution: {integrity: sha512-1URUxUqfHFM1c+zfSPsa3gnkO7Aq21qyH75SIduNYz4SzY964rn1X2vCMQaHSHhktiw+0kPa2iyb6PUpXqB6Vg==}
     engines: {node: '>=20'}
 
   typescript@5.9.3:
@@ -1898,23 +2049,23 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  ufo@1.6.3:
-    resolution: {integrity: sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==}
+  ufo@1.6.4:
+    resolution: {integrity: sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==}
 
   uglify-js@3.19.3:
     resolution: {integrity: sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==}
     engines: {node: '>=0.8.0'}
     hasBin: true
 
-  undici-types@7.16.0:
-    resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
+  undici-types@7.18.2:
+    resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
 
-  undici@6.24.1:
-    resolution: {integrity: sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==}
+  undici@6.26.0:
+    resolution: {integrity: sha512-4yqz8a3n5HmGTlsbADNtr/dJlhkh/55Rq798G6ibiULcXbDtaLpTl1pvdqcbFfeoj3iSi52lePFM7h9H21cw/A==}
     engines: {node: '>=18.17'}
 
-  undici@7.24.7:
-    resolution: {integrity: sha512-H/nlJ/h0ggGC+uRL3ovD+G0i4bqhvsDOpbDv7At5eFLlj2b41L8QliGbnl2H7SnDiYhENphh1tQFJZf+MyfLsQ==}
+  undici@7.27.2:
+    resolution: {integrity: sha512-uZsKNuzQxDMUY6M3pIMvy5tvlGmtq8XJ2oLAkfRKGNu+1VQAIvLy2xIVG5ATZl5wDXl/tddByAWCizRbOme+TA==}
     engines: {node: '>=20.18.1'}
 
   unicode-emoji-modifier-base@1.0.0:
@@ -1994,18 +2145,20 @@ packages:
       yaml:
         optional: true
 
-  vitest@4.1.2:
-    resolution: {integrity: sha512-xjR1dMTVHlFLh98JE3i/f/WePqJsah4A0FK9cc8Ehp9Udk0AZk6ccpIZhh1qJ/yxVWRZ+Q54ocnD8TXmkhspGg==}
+  vitest@4.1.8:
+    resolution: {integrity: sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==}
     engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@opentelemetry/api': ^1.9.0
       '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
-      '@vitest/browser-playwright': 4.1.2
-      '@vitest/browser-preview': 4.1.2
-      '@vitest/browser-webdriverio': 4.1.2
-      '@vitest/ui': 4.1.2
+      '@vitest/browser-playwright': 4.1.8
+      '@vitest/browser-preview': 4.1.8
+      '@vitest/browser-webdriverio': 4.1.8
+      '@vitest/coverage-istanbul': 4.1.8
+      '@vitest/coverage-v8': 4.1.8
+      '@vitest/ui': 4.1.8
       happy-dom: '*'
       jsdom: '*'
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -2021,6 +2174,10 @@ packages:
       '@vitest/browser-preview':
         optional: true
       '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
         optional: true
       '@vitest/ui':
         optional: true
@@ -2083,40 +2240,40 @@ packages:
 
 snapshots:
 
-  '@actions/core@3.0.0':
+  '@actions/core@3.0.1':
     dependencies:
       '@actions/exec': 3.0.0
-      '@actions/http-client': 4.0.0
+      '@actions/http-client': 4.0.1
 
   '@actions/exec@3.0.0':
     dependencies:
       '@actions/io': 3.0.2
 
-  '@actions/http-client@4.0.0':
+  '@actions/http-client@4.0.1':
     dependencies:
       tunnel: 0.0.6
-      undici: 6.24.1
+      undici: 6.26.0
 
   '@actions/io@3.0.2': {}
 
-  '@babel/code-frame@7.29.0':
+  '@babel/code-frame@7.29.7':
     dependencies:
-      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/helper-validator-identifier': 7.29.7
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
-  '@babel/helper-string-parser@7.27.1': {}
+  '@babel/helper-string-parser@7.29.7': {}
 
-  '@babel/helper-validator-identifier@7.28.5': {}
+  '@babel/helper-validator-identifier@7.29.7': {}
 
-  '@babel/parser@7.29.2':
+  '@babel/parser@7.29.7':
     dependencies:
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
 
-  '@babel/types@7.29.0':
+  '@babel/types@7.29.7':
     dependencies:
-      '@babel/helper-string-parser': 7.27.1
-      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/helper-string-parser': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
 
   '@bcoe/v8-coverage@1.0.2': {}
 
@@ -2158,86 +2315,164 @@ snapshots:
   '@colors/colors@1.5.0':
     optional: true
 
-  '@commercelayer/js-auth@7.3.0': {}
+  '@commercelayer/js-auth@7.4.2': {}
 
-  '@commercelayer/sdk@7.10.0': {}
+  '@commercelayer/sdk@7.11.0': {}
 
-  '@esbuild/aix-ppc64@0.27.5':
+  '@esbuild/aix-ppc64@0.27.7':
     optional: true
 
-  '@esbuild/android-arm64@0.27.5':
+  '@esbuild/aix-ppc64@0.28.0':
     optional: true
 
-  '@esbuild/android-arm@0.27.5':
+  '@esbuild/android-arm64@0.27.7':
     optional: true
 
-  '@esbuild/android-x64@0.27.5':
+  '@esbuild/android-arm64@0.28.0':
     optional: true
 
-  '@esbuild/darwin-arm64@0.27.5':
+  '@esbuild/android-arm@0.27.7':
     optional: true
 
-  '@esbuild/darwin-x64@0.27.5':
+  '@esbuild/android-arm@0.28.0':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.27.5':
+  '@esbuild/android-x64@0.27.7':
     optional: true
 
-  '@esbuild/freebsd-x64@0.27.5':
+  '@esbuild/android-x64@0.28.0':
     optional: true
 
-  '@esbuild/linux-arm64@0.27.5':
+  '@esbuild/darwin-arm64@0.27.7':
     optional: true
 
-  '@esbuild/linux-arm@0.27.5':
+  '@esbuild/darwin-arm64@0.28.0':
     optional: true
 
-  '@esbuild/linux-ia32@0.27.5':
+  '@esbuild/darwin-x64@0.27.7':
     optional: true
 
-  '@esbuild/linux-loong64@0.27.5':
+  '@esbuild/darwin-x64@0.28.0':
     optional: true
 
-  '@esbuild/linux-mips64el@0.27.5':
+  '@esbuild/freebsd-arm64@0.27.7':
     optional: true
 
-  '@esbuild/linux-ppc64@0.27.5':
+  '@esbuild/freebsd-arm64@0.28.0':
     optional: true
 
-  '@esbuild/linux-riscv64@0.27.5':
+  '@esbuild/freebsd-x64@0.27.7':
     optional: true
 
-  '@esbuild/linux-s390x@0.27.5':
+  '@esbuild/freebsd-x64@0.28.0':
     optional: true
 
-  '@esbuild/linux-x64@0.27.5':
+  '@esbuild/linux-arm64@0.27.7':
     optional: true
 
-  '@esbuild/netbsd-arm64@0.27.5':
+  '@esbuild/linux-arm64@0.28.0':
     optional: true
 
-  '@esbuild/netbsd-x64@0.27.5':
+  '@esbuild/linux-arm@0.27.7':
     optional: true
 
-  '@esbuild/openbsd-arm64@0.27.5':
+  '@esbuild/linux-arm@0.28.0':
     optional: true
 
-  '@esbuild/openbsd-x64@0.27.5':
+  '@esbuild/linux-ia32@0.27.7':
     optional: true
 
-  '@esbuild/openharmony-arm64@0.27.5':
+  '@esbuild/linux-ia32@0.28.0':
     optional: true
 
-  '@esbuild/sunos-x64@0.27.5':
+  '@esbuild/linux-loong64@0.27.7':
     optional: true
 
-  '@esbuild/win32-arm64@0.27.5':
+  '@esbuild/linux-loong64@0.28.0':
     optional: true
 
-  '@esbuild/win32-ia32@0.27.5':
+  '@esbuild/linux-mips64el@0.27.7':
     optional: true
 
-  '@esbuild/win32-x64@0.27.5':
+  '@esbuild/linux-mips64el@0.28.0':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.0':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.28.0':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.7':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.0':
+    optional: true
+
+  '@esbuild/linux-x64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-x64@0.28.0':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.28.0':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.28.0':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/sunos-x64@0.27.7':
+    optional: true
+
+  '@esbuild/sunos-x64@0.28.0':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/win32-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/win32-ia32@0.28.0':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.0':
     optional: true
 
   '@jridgewell/gen-mapping@0.3.13':
@@ -2260,7 +2495,7 @@ snapshots:
     dependencies:
       '@octokit/auth-token': 6.0.0
       '@octokit/graphql': 9.0.3
-      '@octokit/request': 10.0.8
+      '@octokit/request': 10.0.10
       '@octokit/request-error': 7.1.0
       '@octokit/types': 16.0.0
       before-after-hook: 4.0.0
@@ -2273,7 +2508,7 @@ snapshots:
 
   '@octokit/graphql@9.0.3':
     dependencies:
-      '@octokit/request': 10.0.8
+      '@octokit/request': 10.0.10
       '@octokit/types': 16.0.0
       universal-user-agent: 7.0.3
 
@@ -2301,12 +2536,12 @@ snapshots:
     dependencies:
       '@octokit/types': 16.0.0
 
-  '@octokit/request@10.0.8':
+  '@octokit/request@10.0.10':
     dependencies:
       '@octokit/endpoint': 11.0.3
       '@octokit/request-error': 7.1.0
       '@octokit/types': 16.0.0
-      fast-content-type-parse: 3.0.0
+      content-type: 2.0.0
       json-with-bigint: 3.5.8
       universal-user-agent: 7.0.3
 
@@ -2326,92 +2561,92 @@ snapshots:
       '@pnpm/network.ca-file': 1.0.2
       config-chain: 1.1.13
 
-  '@rollup/rollup-android-arm-eabi@4.60.1':
+  '@rollup/rollup-android-arm-eabi@4.61.1':
     optional: true
 
-  '@rollup/rollup-android-arm64@4.60.1':
+  '@rollup/rollup-android-arm64@4.61.1':
     optional: true
 
-  '@rollup/rollup-darwin-arm64@4.60.1':
+  '@rollup/rollup-darwin-arm64@4.61.1':
     optional: true
 
-  '@rollup/rollup-darwin-x64@4.60.1':
+  '@rollup/rollup-darwin-x64@4.61.1':
     optional: true
 
-  '@rollup/rollup-freebsd-arm64@4.60.1':
+  '@rollup/rollup-freebsd-arm64@4.61.1':
     optional: true
 
-  '@rollup/rollup-freebsd-x64@4.60.1':
+  '@rollup/rollup-freebsd-x64@4.61.1':
     optional: true
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.60.1':
+  '@rollup/rollup-linux-arm-gnueabihf@4.61.1':
     optional: true
 
-  '@rollup/rollup-linux-arm-musleabihf@4.60.1':
+  '@rollup/rollup-linux-arm-musleabihf@4.61.1':
     optional: true
 
-  '@rollup/rollup-linux-arm64-gnu@4.60.1':
+  '@rollup/rollup-linux-arm64-gnu@4.61.1':
     optional: true
 
-  '@rollup/rollup-linux-arm64-musl@4.60.1':
+  '@rollup/rollup-linux-arm64-musl@4.61.1':
     optional: true
 
-  '@rollup/rollup-linux-loong64-gnu@4.60.1':
+  '@rollup/rollup-linux-loong64-gnu@4.61.1':
     optional: true
 
-  '@rollup/rollup-linux-loong64-musl@4.60.1':
+  '@rollup/rollup-linux-loong64-musl@4.61.1':
     optional: true
 
-  '@rollup/rollup-linux-ppc64-gnu@4.60.1':
+  '@rollup/rollup-linux-ppc64-gnu@4.61.1':
     optional: true
 
-  '@rollup/rollup-linux-ppc64-musl@4.60.1':
+  '@rollup/rollup-linux-ppc64-musl@4.61.1':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-gnu@4.60.1':
+  '@rollup/rollup-linux-riscv64-gnu@4.61.1':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-musl@4.60.1':
+  '@rollup/rollup-linux-riscv64-musl@4.61.1':
     optional: true
 
-  '@rollup/rollup-linux-s390x-gnu@4.60.1':
+  '@rollup/rollup-linux-s390x-gnu@4.61.1':
     optional: true
 
-  '@rollup/rollup-linux-x64-gnu@4.60.1':
+  '@rollup/rollup-linux-x64-gnu@4.61.1':
     optional: true
 
-  '@rollup/rollup-linux-x64-musl@4.60.1':
+  '@rollup/rollup-linux-x64-musl@4.61.1':
     optional: true
 
-  '@rollup/rollup-openbsd-x64@4.60.1':
+  '@rollup/rollup-openbsd-x64@4.61.1':
     optional: true
 
-  '@rollup/rollup-openharmony-arm64@4.60.1':
+  '@rollup/rollup-openharmony-arm64@4.61.1':
     optional: true
 
-  '@rollup/rollup-win32-arm64-msvc@4.60.1':
+  '@rollup/rollup-win32-arm64-msvc@4.61.1':
     optional: true
 
-  '@rollup/rollup-win32-ia32-msvc@4.60.1':
+  '@rollup/rollup-win32-ia32-msvc@4.61.1':
     optional: true
 
-  '@rollup/rollup-win32-x64-gnu@4.60.1':
+  '@rollup/rollup-win32-x64-gnu@4.61.1':
     optional: true
 
-  '@rollup/rollup-win32-x64-msvc@4.60.1':
+  '@rollup/rollup-win32-x64-msvc@4.61.1':
     optional: true
 
   '@sec-ant/readable-stream@0.4.1': {}
 
-  '@semantic-release/changelog@6.0.3(semantic-release@25.0.3(typescript@5.9.3))':
+  '@semantic-release/changelog@6.0.3(semantic-release@25.0.5(typescript@5.9.3))':
     dependencies:
       '@semantic-release/error': 3.0.0
       aggregate-error: 3.1.0
-      fs-extra: 11.3.4
+      fs-extra: 11.3.5
       lodash: 4.18.1
-      semantic-release: 25.0.3(typescript@5.9.3)
+      semantic-release: 25.0.5(typescript@5.9.3)
 
-  '@semantic-release/commit-analyzer@13.0.1(semantic-release@25.0.3(typescript@5.9.3))':
+  '@semantic-release/commit-analyzer@13.0.1(semantic-release@25.0.5(typescript@5.9.3))':
     dependencies:
       conventional-changelog-angular: 8.3.1
       conventional-changelog-writer: 8.4.0
@@ -2421,7 +2656,7 @@ snapshots:
       import-from-esm: 2.0.0
       lodash-es: 4.18.1
       micromatch: 4.0.8
-      semantic-release: 25.0.3(typescript@5.9.3)
+      semantic-release: 25.0.5(typescript@5.9.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -2429,7 +2664,7 @@ snapshots:
 
   '@semantic-release/error@4.0.0': {}
 
-  '@semantic-release/git@10.0.1(semantic-release@25.0.3(typescript@5.9.3))':
+  '@semantic-release/git@10.0.1(semantic-release@25.0.5(typescript@5.9.3))':
     dependencies:
       '@semantic-release/error': 3.0.0
       aggregate-error: 3.1.0
@@ -2439,11 +2674,11 @@ snapshots:
       lodash: 4.18.1
       micromatch: 4.0.8
       p-reduce: 2.1.0
-      semantic-release: 25.0.3(typescript@5.9.3)
+      semantic-release: 25.0.5(typescript@5.9.3)
     transitivePeerDependencies:
       - supports-color
 
-  '@semantic-release/github@12.0.6(semantic-release@25.0.3(typescript@5.9.3))':
+  '@semantic-release/github@12.0.8(semantic-release@25.0.5(typescript@5.9.3))':
     dependencies:
       '@octokit/core': 7.0.6
       '@octokit/plugin-paginate-rest': 14.0.0(@octokit/core@7.0.6)
@@ -2453,51 +2688,50 @@ snapshots:
       aggregate-error: 5.0.0
       debug: 4.4.3
       dir-glob: 3.0.1
-      http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.6
-      issue-parser: 7.0.1
+      http-proxy-agent: 9.1.0
+      https-proxy-agent: 9.1.0
+      issue-parser: 7.0.2
       lodash-es: 4.18.1
       mime: 4.1.0
       p-filter: 4.1.0
-      semantic-release: 25.0.3(typescript@5.9.3)
-      tinyglobby: 0.2.15
-      undici: 7.24.7
+      semantic-release: 25.0.5(typescript@5.9.3)
+      tinyglobby: 0.2.17
+      undici: 7.27.2
       url-join: 5.0.0
     transitivePeerDependencies:
+      - kerberos
       - supports-color
 
-  '@semantic-release/npm@13.1.5(semantic-release@25.0.3(typescript@5.9.3))':
+  '@semantic-release/npm@13.1.5(semantic-release@25.0.5(typescript@5.9.3))':
     dependencies:
-      '@actions/core': 3.0.0
+      '@actions/core': 3.0.1
       '@semantic-release/error': 4.0.0
       aggregate-error: 5.0.0
       env-ci: 11.2.0
       execa: 9.6.1
-      fs-extra: 11.3.4
+      fs-extra: 11.3.5
       lodash-es: 4.18.1
       nerf-dart: 1.0.0
-      normalize-url: 9.0.0
-      npm: 11.12.1
+      normalize-url: 9.0.1
+      npm: 11.16.0
       rc: 1.2.8
       read-pkg: 10.1.0
       registry-auth-token: 5.1.1
-      semantic-release: 25.0.3(typescript@5.9.3)
-      semver: 7.7.4
+      semantic-release: 25.0.5(typescript@5.9.3)
+      semver: 7.8.4
       tempy: 3.2.0
 
-  '@semantic-release/release-notes-generator@14.1.0(semantic-release@25.0.3(typescript@5.9.3))':
+  '@semantic-release/release-notes-generator@14.1.1(semantic-release@25.0.5(typescript@5.9.3))':
     dependencies:
       conventional-changelog-angular: 8.3.1
       conventional-changelog-writer: 8.4.0
       conventional-commits-filter: 5.0.0
       conventional-commits-parser: 6.4.0
       debug: 4.4.3
-      get-stream: 7.0.1
       import-from-esm: 2.0.0
-      into-stream: 7.0.0
       lodash-es: 4.18.1
       read-package-up: 11.0.0
-      semantic-release: 25.0.3(typescript@5.9.3)
+      semantic-release: 25.0.5(typescript@5.9.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -2516,72 +2750,72 @@ snapshots:
 
   '@types/deep-eql@4.0.2': {}
 
-  '@types/estree@1.0.8': {}
+  '@types/estree@1.0.9': {}
 
-  '@types/node@24.12.0':
+  '@types/node@24.13.2':
     dependencies:
-      undici-types: 7.16.0
+      undici-types: 7.18.2
 
   '@types/normalize-package-data@2.4.4': {}
 
-  '@vitest/coverage-v8@4.1.2(vitest@4.1.2(@types/node@24.12.0)(vite@7.3.1(@types/node@24.12.0)(tsx@4.21.0)))':
+  '@vitest/coverage-v8@4.1.8(vitest@4.1.8)':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
-      '@vitest/utils': 4.1.2
-      ast-v8-to-istanbul: 1.0.0
+      '@vitest/utils': 4.1.8
+      ast-v8-to-istanbul: 1.0.4
       istanbul-lib-coverage: 3.2.2
       istanbul-lib-report: 3.0.1
       istanbul-reports: 3.2.0
-      magicast: 0.5.2
-      obug: 2.1.1
-      std-env: 4.0.0
+      magicast: 0.5.3
+      obug: 2.1.2
+      std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.2(@types/node@24.12.0)(vite@7.3.1(@types/node@24.12.0)(tsx@4.21.0))
+      vitest: 4.1.8(@types/node@24.13.2)(@vitest/coverage-v8@4.1.8)(vite@7.3.1(@types/node@24.13.2)(tsx@4.22.4))
 
-  '@vitest/expect@4.1.2':
+  '@vitest/expect@4.1.8':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@types/chai': 5.2.3
-      '@vitest/spy': 4.1.2
-      '@vitest/utils': 4.1.2
+      '@vitest/spy': 4.1.8
+      '@vitest/utils': 4.1.8
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.2(vite@7.3.1(@types/node@24.12.0)(tsx@4.21.0))':
+  '@vitest/mocker@4.1.8(vite@7.3.1(@types/node@24.13.2)(tsx@4.22.4))':
     dependencies:
-      '@vitest/spy': 4.1.2
+      '@vitest/spy': 4.1.8
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@24.12.0)(tsx@4.21.0)
+      vite: 7.3.1(@types/node@24.13.2)(tsx@4.22.4)
 
-  '@vitest/pretty-format@4.1.2':
+  '@vitest/pretty-format@4.1.8':
     dependencies:
       tinyrainbow: 3.1.0
 
-  '@vitest/runner@4.1.2':
+  '@vitest/runner@4.1.8':
     dependencies:
-      '@vitest/utils': 4.1.2
+      '@vitest/utils': 4.1.8
       pathe: 2.0.3
 
-  '@vitest/snapshot@4.1.2':
+  '@vitest/snapshot@4.1.8':
     dependencies:
-      '@vitest/pretty-format': 4.1.2
-      '@vitest/utils': 4.1.2
+      '@vitest/pretty-format': 4.1.8
+      '@vitest/utils': 4.1.8
       magic-string: 0.30.21
       pathe: 2.0.3
 
-  '@vitest/spy@4.1.2': {}
+  '@vitest/spy@4.1.8': {}
 
-  '@vitest/utils@4.1.2':
+  '@vitest/utils@4.1.8':
     dependencies:
-      '@vitest/pretty-format': 4.1.2
+      '@vitest/pretty-format': 4.1.8
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
   acorn@8.16.0: {}
 
-  agent-base@7.1.4: {}
+  agent-base@9.0.0: {}
 
   aggregate-error@3.1.0:
     dependencies:
@@ -2621,7 +2855,7 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
-  ast-v8-to-istanbul@1.0.0:
+  ast-v8-to-istanbul@1.0.4:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       estree-walker: 3.0.3
@@ -2635,9 +2869,9 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
-  bundle-require@5.1.0(esbuild@0.27.5):
+  bundle-require@5.1.0(esbuild@0.27.7):
     dependencies:
-      esbuild: 0.27.5
+      esbuild: 0.27.7
       load-tsconfig: 0.2.5
 
   cac@6.7.14: {}
@@ -2726,6 +2960,8 @@ snapshots:
 
   consola@3.4.2: {}
 
+  content-type@2.0.0: {}
+
   conventional-changelog-angular@8.3.1:
     dependencies:
       compare-func: 2.0.0
@@ -2740,7 +2976,7 @@ snapshots:
       conventional-commits-filter: 5.0.0
       handlebars: 4.7.9
       meow: 13.2.0
-      semver: 7.7.4
+      semver: 7.8.4
 
   conventional-commits-filter@5.0.0: {}
 
@@ -2755,11 +2991,11 @@ snapshots:
 
   core-util-is@1.0.3: {}
 
-  cosmiconfig@9.0.1(typescript@5.9.3):
+  cosmiconfig@9.0.2(typescript@5.9.3):
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.1
-      js-yaml: 4.1.1
+      js-yaml: 4.2.0
       parse-json: 5.2.0
     optionalDependencies:
       typescript: 5.9.3
@@ -2813,36 +3049,65 @@ snapshots:
     dependencies:
       is-arrayish: 0.2.1
 
-  es-module-lexer@2.0.0: {}
+  es-module-lexer@2.1.0: {}
 
-  esbuild@0.27.5:
+  esbuild@0.27.7:
     optionalDependencies:
-      '@esbuild/aix-ppc64': 0.27.5
-      '@esbuild/android-arm': 0.27.5
-      '@esbuild/android-arm64': 0.27.5
-      '@esbuild/android-x64': 0.27.5
-      '@esbuild/darwin-arm64': 0.27.5
-      '@esbuild/darwin-x64': 0.27.5
-      '@esbuild/freebsd-arm64': 0.27.5
-      '@esbuild/freebsd-x64': 0.27.5
-      '@esbuild/linux-arm': 0.27.5
-      '@esbuild/linux-arm64': 0.27.5
-      '@esbuild/linux-ia32': 0.27.5
-      '@esbuild/linux-loong64': 0.27.5
-      '@esbuild/linux-mips64el': 0.27.5
-      '@esbuild/linux-ppc64': 0.27.5
-      '@esbuild/linux-riscv64': 0.27.5
-      '@esbuild/linux-s390x': 0.27.5
-      '@esbuild/linux-x64': 0.27.5
-      '@esbuild/netbsd-arm64': 0.27.5
-      '@esbuild/netbsd-x64': 0.27.5
-      '@esbuild/openbsd-arm64': 0.27.5
-      '@esbuild/openbsd-x64': 0.27.5
-      '@esbuild/openharmony-arm64': 0.27.5
-      '@esbuild/sunos-x64': 0.27.5
-      '@esbuild/win32-arm64': 0.27.5
-      '@esbuild/win32-ia32': 0.27.5
-      '@esbuild/win32-x64': 0.27.5
+      '@esbuild/aix-ppc64': 0.27.7
+      '@esbuild/android-arm': 0.27.7
+      '@esbuild/android-arm64': 0.27.7
+      '@esbuild/android-x64': 0.27.7
+      '@esbuild/darwin-arm64': 0.27.7
+      '@esbuild/darwin-x64': 0.27.7
+      '@esbuild/freebsd-arm64': 0.27.7
+      '@esbuild/freebsd-x64': 0.27.7
+      '@esbuild/linux-arm': 0.27.7
+      '@esbuild/linux-arm64': 0.27.7
+      '@esbuild/linux-ia32': 0.27.7
+      '@esbuild/linux-loong64': 0.27.7
+      '@esbuild/linux-mips64el': 0.27.7
+      '@esbuild/linux-ppc64': 0.27.7
+      '@esbuild/linux-riscv64': 0.27.7
+      '@esbuild/linux-s390x': 0.27.7
+      '@esbuild/linux-x64': 0.27.7
+      '@esbuild/netbsd-arm64': 0.27.7
+      '@esbuild/netbsd-x64': 0.27.7
+      '@esbuild/openbsd-arm64': 0.27.7
+      '@esbuild/openbsd-x64': 0.27.7
+      '@esbuild/openharmony-arm64': 0.27.7
+      '@esbuild/sunos-x64': 0.27.7
+      '@esbuild/win32-arm64': 0.27.7
+      '@esbuild/win32-ia32': 0.27.7
+      '@esbuild/win32-x64': 0.27.7
+
+  esbuild@0.28.0:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.0
+      '@esbuild/android-arm': 0.28.0
+      '@esbuild/android-arm64': 0.28.0
+      '@esbuild/android-x64': 0.28.0
+      '@esbuild/darwin-arm64': 0.28.0
+      '@esbuild/darwin-x64': 0.28.0
+      '@esbuild/freebsd-arm64': 0.28.0
+      '@esbuild/freebsd-x64': 0.28.0
+      '@esbuild/linux-arm': 0.28.0
+      '@esbuild/linux-arm64': 0.28.0
+      '@esbuild/linux-ia32': 0.28.0
+      '@esbuild/linux-loong64': 0.28.0
+      '@esbuild/linux-mips64el': 0.28.0
+      '@esbuild/linux-ppc64': 0.28.0
+      '@esbuild/linux-riscv64': 0.28.0
+      '@esbuild/linux-s390x': 0.28.0
+      '@esbuild/linux-x64': 0.28.0
+      '@esbuild/netbsd-arm64': 0.28.0
+      '@esbuild/netbsd-x64': 0.28.0
+      '@esbuild/openbsd-arm64': 0.28.0
+      '@esbuild/openbsd-x64': 0.28.0
+      '@esbuild/openharmony-arm64': 0.28.0
+      '@esbuild/sunos-x64': 0.28.0
+      '@esbuild/win32-arm64': 0.28.0
+      '@esbuild/win32-ia32': 0.28.0
+      '@esbuild/win32-x64': 0.28.0
 
   escalade@3.2.0: {}
 
@@ -2852,7 +3117,7 @@ snapshots:
 
   estree-walker@3.0.3:
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
 
   execa@5.1.1:
     dependencies:
@@ -2895,8 +3160,6 @@ snapshots:
 
   expect-type@1.3.0: {}
 
-  fast-content-type-parse@3.0.0: {}
-
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
@@ -2928,17 +3191,12 @@ snapshots:
     dependencies:
       magic-string: 0.30.21
       mlly: 1.8.2
-      rollup: 4.60.1
+      rollup: 4.61.1
 
-  from2@2.3.0:
-    dependencies:
-      inherits: 2.0.4
-      readable-stream: 2.3.8
-
-  fs-extra@11.3.4:
+  fs-extra@11.3.5:
     dependencies:
       graceful-fs: 4.2.11
-      jsonfile: 6.2.0
+      jsonfile: 6.2.1
       universalify: 2.0.1
 
   fsevents@2.3.3:
@@ -2948,11 +3206,9 @@ snapshots:
 
   get-caller-file@2.0.5: {}
 
-  get-east-asian-width@1.5.0: {}
+  get-east-asian-width@1.6.0: {}
 
   get-stream@6.0.1: {}
-
-  get-stream@7.0.1: {}
 
   get-stream@8.0.1: {}
 
@@ -2960,10 +3216,6 @@ snapshots:
     dependencies:
       '@sec-ant/readable-stream': 0.4.1
       is-stream: 4.0.1
-
-  get-tsconfig@4.13.7:
-    dependencies:
-      resolve-pkg-maps: 1.0.0
 
   git-log-parser@1.2.1:
     dependencies:
@@ -2999,24 +3251,28 @@ snapshots:
     dependencies:
       lru-cache: 10.4.3
 
-  hosted-git-info@9.0.2:
+  hosted-git-info@9.0.3:
     dependencies:
-      lru-cache: 11.2.7
+      lru-cache: 11.5.1
 
   html-escaper@2.0.2: {}
 
-  http-proxy-agent@7.0.2:
+  http-proxy-agent@9.1.0:
     dependencies:
-      agent-base: 7.1.4
+      agent-base: 9.0.0
       debug: 4.4.3
+      proxy-agent-negotiate: 1.1.0
     transitivePeerDependencies:
+      - kerberos
       - supports-color
 
-  https-proxy-agent@7.0.6:
+  https-proxy-agent@9.1.0:
     dependencies:
-      agent-base: 7.1.4
+      agent-base: 9.0.0
       debug: 4.4.3
+      proxy-agent-negotiate: 1.1.0
     transitivePeerDependencies:
+      - kerberos
       - supports-color
 
   human-signals@2.1.0: {}
@@ -3049,11 +3305,6 @@ snapshots:
 
   ini@1.3.8: {}
 
-  into-stream@7.0.0:
-    dependencies:
-      from2: 2.3.0
-      p-is-promise: 3.0.0
-
   is-arrayish@0.2.1: {}
 
   is-fullwidth-code-point@3.0.0: {}
@@ -3076,7 +3327,7 @@ snapshots:
 
   isexe@2.0.0: {}
 
-  issue-parser@7.0.1:
+  issue-parser@7.0.2:
     dependencies:
       lodash.capitalize: 4.2.1
       lodash.escaperegexp: 4.1.2
@@ -3105,7 +3356,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.1.1:
+  js-yaml@4.2.0:
     dependencies:
       argparse: 2.0.1
 
@@ -3121,7 +3372,7 @@ snapshots:
     dependencies:
       json-typescript: 1.1.2
 
-  jsonfile@6.2.0:
+  jsonfile@6.2.1:
     dependencies:
       universalify: 2.0.1
     optionalDependencies:
@@ -3161,16 +3412,16 @@ snapshots:
 
   lru-cache@10.4.3: {}
 
-  lru-cache@11.2.7: {}
+  lru-cache@11.5.1: {}
 
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  magicast@0.5.2:
+  magicast@0.5.3:
     dependencies:
-      '@babel/parser': 7.29.2
-      '@babel/types': 7.29.0
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
       source-map-js: 1.2.1
 
   make-asynchronous@1.1.0:
@@ -3181,7 +3432,7 @@ snapshots:
 
   make-dir@4.0.0:
     dependencies:
-      semver: 7.7.4
+      semver: 7.8.4
 
   marked-terminal@7.3.0(marked@15.0.12):
     dependencies:
@@ -3218,7 +3469,7 @@ snapshots:
       acorn: 8.16.0
       pathe: 2.0.3
       pkg-types: 1.3.1
-      ufo: 1.6.3
+      ufo: 1.6.4
 
   ms@2.1.3: {}
 
@@ -3228,7 +3479,7 @@ snapshots:
       object-assign: 4.1.1
       thenify-all: 1.6.0
 
-  nanoid@3.3.11: {}
+  nanoid@3.3.12: {}
 
   neo-async@2.6.2: {}
 
@@ -3244,16 +3495,16 @@ snapshots:
   normalize-package-data@6.0.2:
     dependencies:
       hosted-git-info: 7.0.2
-      semver: 7.7.4
+      semver: 7.8.4
       validate-npm-package-license: 3.0.4
 
   normalize-package-data@8.0.0:
     dependencies:
-      hosted-git-info: 9.0.2
-      semver: 7.7.4
+      hosted-git-info: 9.0.3
+      semver: 7.8.4
       validate-npm-package-license: 3.0.4
 
-  normalize-url@9.0.0: {}
+  normalize-url@9.0.1: {}
 
   npm-run-path@4.0.1:
     dependencies:
@@ -3268,11 +3519,11 @@ snapshots:
       path-key: 4.0.0
       unicorn-magic: 0.3.0
 
-  npm@11.12.1: {}
+  npm@11.16.0: {}
 
   object-assign@4.1.1: {}
 
-  obug@2.1.1: {}
+  obug@2.1.2: {}
 
   onetime@5.1.2:
     dependencies:
@@ -3291,8 +3542,6 @@ snapshots:
   p-filter@4.1.0:
     dependencies:
       p-map: 7.0.4
-
-  p-is-promise@3.0.0: {}
 
   p-limit@1.3.0:
     dependencies:
@@ -3323,14 +3572,14 @@ snapshots:
 
   parse-json@5.2.0:
     dependencies:
-      '@babel/code-frame': 7.29.0
+      '@babel/code-frame': 7.29.7
       error-ex: 1.3.4
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
 
   parse-json@8.3.0:
     dependencies:
-      '@babel/code-frame': 7.29.0
+      '@babel/code-frame': 7.29.7
       index-to-position: 1.2.0
       type-fest: 4.41.0
 
@@ -3375,16 +3624,16 @@ snapshots:
       mlly: 1.8.2
       pathe: 2.0.3
 
-  postcss-load-config@6.0.1(postcss@8.5.8)(tsx@4.21.0):
+  postcss-load-config@6.0.1(postcss@8.5.15)(tsx@4.22.4):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
-      postcss: 8.5.8
-      tsx: 4.21.0
+      postcss: 8.5.15
+      tsx: 4.22.4
 
-  postcss@8.5.8:
+  postcss@8.5.15:
     dependencies:
-      nanoid: 3.3.11
+      nanoid: 3.3.12
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -3395,6 +3644,8 @@ snapshots:
   process-nextick-args@2.0.1: {}
 
   proto-list@1.2.4: {}
+
+  proxy-agent-negotiate@1.1.0: {}
 
   rc@1.2.8:
     dependencies:
@@ -3413,14 +3664,14 @@ snapshots:
     dependencies:
       find-up-simple: 1.0.1
       read-pkg: 10.1.0
-      type-fest: 5.5.0
+      type-fest: 5.7.0
 
   read-pkg@10.1.0:
     dependencies:
       '@types/normalize-package-data': 2.4.4
       normalize-package-data: 8.0.0
       parse-json: 8.3.0
-      type-fest: 5.5.0
+      type-fest: 5.7.0
       unicorn-magic: 0.4.0
 
   read-pkg@9.0.1:
@@ -3453,50 +3704,48 @@ snapshots:
 
   resolve-from@5.0.0: {}
 
-  resolve-pkg-maps@1.0.0: {}
-
-  rollup@4.60.1:
+  rollup@4.61.1:
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
     optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.60.1
-      '@rollup/rollup-android-arm64': 4.60.1
-      '@rollup/rollup-darwin-arm64': 4.60.1
-      '@rollup/rollup-darwin-x64': 4.60.1
-      '@rollup/rollup-freebsd-arm64': 4.60.1
-      '@rollup/rollup-freebsd-x64': 4.60.1
-      '@rollup/rollup-linux-arm-gnueabihf': 4.60.1
-      '@rollup/rollup-linux-arm-musleabihf': 4.60.1
-      '@rollup/rollup-linux-arm64-gnu': 4.60.1
-      '@rollup/rollup-linux-arm64-musl': 4.60.1
-      '@rollup/rollup-linux-loong64-gnu': 4.60.1
-      '@rollup/rollup-linux-loong64-musl': 4.60.1
-      '@rollup/rollup-linux-ppc64-gnu': 4.60.1
-      '@rollup/rollup-linux-ppc64-musl': 4.60.1
-      '@rollup/rollup-linux-riscv64-gnu': 4.60.1
-      '@rollup/rollup-linux-riscv64-musl': 4.60.1
-      '@rollup/rollup-linux-s390x-gnu': 4.60.1
-      '@rollup/rollup-linux-x64-gnu': 4.60.1
-      '@rollup/rollup-linux-x64-musl': 4.60.1
-      '@rollup/rollup-openbsd-x64': 4.60.1
-      '@rollup/rollup-openharmony-arm64': 4.60.1
-      '@rollup/rollup-win32-arm64-msvc': 4.60.1
-      '@rollup/rollup-win32-ia32-msvc': 4.60.1
-      '@rollup/rollup-win32-x64-gnu': 4.60.1
-      '@rollup/rollup-win32-x64-msvc': 4.60.1
+      '@rollup/rollup-android-arm-eabi': 4.61.1
+      '@rollup/rollup-android-arm64': 4.61.1
+      '@rollup/rollup-darwin-arm64': 4.61.1
+      '@rollup/rollup-darwin-x64': 4.61.1
+      '@rollup/rollup-freebsd-arm64': 4.61.1
+      '@rollup/rollup-freebsd-x64': 4.61.1
+      '@rollup/rollup-linux-arm-gnueabihf': 4.61.1
+      '@rollup/rollup-linux-arm-musleabihf': 4.61.1
+      '@rollup/rollup-linux-arm64-gnu': 4.61.1
+      '@rollup/rollup-linux-arm64-musl': 4.61.1
+      '@rollup/rollup-linux-loong64-gnu': 4.61.1
+      '@rollup/rollup-linux-loong64-musl': 4.61.1
+      '@rollup/rollup-linux-ppc64-gnu': 4.61.1
+      '@rollup/rollup-linux-ppc64-musl': 4.61.1
+      '@rollup/rollup-linux-riscv64-gnu': 4.61.1
+      '@rollup/rollup-linux-riscv64-musl': 4.61.1
+      '@rollup/rollup-linux-s390x-gnu': 4.61.1
+      '@rollup/rollup-linux-x64-gnu': 4.61.1
+      '@rollup/rollup-linux-x64-musl': 4.61.1
+      '@rollup/rollup-openbsd-x64': 4.61.1
+      '@rollup/rollup-openharmony-arm64': 4.61.1
+      '@rollup/rollup-win32-arm64-msvc': 4.61.1
+      '@rollup/rollup-win32-ia32-msvc': 4.61.1
+      '@rollup/rollup-win32-x64-gnu': 4.61.1
+      '@rollup/rollup-win32-x64-msvc': 4.61.1
       fsevents: 2.3.3
 
   safe-buffer@5.1.2: {}
 
-  semantic-release@25.0.3(typescript@5.9.3):
+  semantic-release@25.0.5(typescript@5.9.3):
     dependencies:
-      '@semantic-release/commit-analyzer': 13.0.1(semantic-release@25.0.3(typescript@5.9.3))
+      '@semantic-release/commit-analyzer': 13.0.1(semantic-release@25.0.5(typescript@5.9.3))
       '@semantic-release/error': 4.0.0
-      '@semantic-release/github': 12.0.6(semantic-release@25.0.3(typescript@5.9.3))
-      '@semantic-release/npm': 13.1.5(semantic-release@25.0.3(typescript@5.9.3))
-      '@semantic-release/release-notes-generator': 14.1.0(semantic-release@25.0.3(typescript@5.9.3))
+      '@semantic-release/github': 12.0.8(semantic-release@25.0.5(typescript@5.9.3))
+      '@semantic-release/npm': 13.1.5(semantic-release@25.0.5(typescript@5.9.3))
+      '@semantic-release/release-notes-generator': 14.1.1(semantic-release@25.0.5(typescript@5.9.3))
       aggregate-error: 5.0.0
-      cosmiconfig: 9.0.1(typescript@5.9.3)
+      cosmiconfig: 9.0.2(typescript@5.9.3)
       debug: 4.4.3
       env-ci: 11.2.0
       execa: 9.6.1
@@ -3505,7 +3754,7 @@ snapshots:
       get-stream: 6.0.1
       git-log-parser: 1.2.1
       hook-std: 4.0.0
-      hosted-git-info: 9.0.2
+      hosted-git-info: 9.0.3
       import-from-esm: 2.0.0
       lodash-es: 4.18.1
       marked: 15.0.12
@@ -3515,16 +3764,17 @@ snapshots:
       p-reduce: 3.0.0
       read-package-up: 12.0.0
       resolve-from: 5.0.0
-      semver: 7.7.4
+      semver: 7.8.4
       signale: 1.4.0
       yargs: 18.0.0
     transitivePeerDependencies:
+      - kerberos
       - supports-color
       - typescript
 
   semver-regex@4.0.5: {}
 
-  semver@7.7.4: {}
+  semver@7.8.4: {}
 
   shebang-command@2.0.0:
     dependencies:
@@ -3576,7 +3826,7 @@ snapshots:
 
   stackback@0.0.2: {}
 
-  std-env@4.0.0: {}
+  std-env@4.1.0: {}
 
   stream-combiner2@1.1.1:
     dependencies:
@@ -3592,7 +3842,7 @@ snapshots:
   string-width@7.2.0:
     dependencies:
       emoji-regex: 10.6.0
-      get-east-asian-width: 1.5.0
+      get-east-asian-width: 1.6.0
       strip-ansi: 7.2.0
 
   string_decoder@1.1.1:
@@ -3624,7 +3874,7 @@ snapshots:
       lines-and-columns: 1.2.4
       mz: 2.7.0
       pirates: 4.0.7
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.17
       ts-interface-checker: 0.1.13
 
   super-regex@1.1.0:
@@ -3678,9 +3928,9 @@ snapshots:
 
   tinyexec@0.3.2: {}
 
-  tinyexec@1.0.4: {}
+  tinyexec@1.2.4: {}
 
-  tinyglobby@0.2.15:
+  tinyglobby@0.2.17:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
@@ -3697,27 +3947,27 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  tsup@8.5.1(postcss@8.5.8)(tsx@4.21.0)(typescript@5.9.3):
+  tsup@8.5.1(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3):
     dependencies:
-      bundle-require: 5.1.0(esbuild@0.27.5)
+      bundle-require: 5.1.0(esbuild@0.27.7)
       cac: 6.7.14
       chokidar: 4.0.3
       consola: 3.4.2
       debug: 4.4.3
-      esbuild: 0.27.5
+      esbuild: 0.27.7
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1
-      postcss-load-config: 6.0.1(postcss@8.5.8)(tsx@4.21.0)
+      postcss-load-config: 6.0.1(postcss@8.5.15)(tsx@4.22.4)
       resolve-from: 5.0.0
-      rollup: 4.60.1
+      rollup: 4.61.1
       source-map: 0.7.6
       sucrase: 3.35.1
       tinyexec: 0.3.2
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.17
       tree-kill: 1.2.2
     optionalDependencies:
-      postcss: 8.5.8
+      postcss: 8.5.15
       typescript: 5.9.3
     transitivePeerDependencies:
       - jiti
@@ -3725,10 +3975,9 @@ snapshots:
       - tsx
       - yaml
 
-  tsx@4.21.0:
+  tsx@4.22.4:
     dependencies:
-      esbuild: 0.27.5
-      get-tsconfig: 4.13.7
+      esbuild: 0.28.0
     optionalDependencies:
       fsevents: 2.3.3
 
@@ -3740,22 +3989,22 @@ snapshots:
 
   type-fest@4.41.0: {}
 
-  type-fest@5.5.0:
+  type-fest@5.7.0:
     dependencies:
       tagged-tag: 1.0.0
 
   typescript@5.9.3: {}
 
-  ufo@1.6.3: {}
+  ufo@1.6.4: {}
 
   uglify-js@3.19.3:
     optional: true
 
-  undici-types@7.16.0: {}
+  undici-types@7.18.2: {}
 
-  undici@6.24.1: {}
+  undici@6.26.0: {}
 
-  undici@7.24.7: {}
+  undici@7.27.2: {}
 
   unicode-emoji-modifier-base@1.0.0: {}
 
@@ -3782,43 +4031,44 @@ snapshots:
       spdx-correct: 3.2.0
       spdx-expression-parse: 3.0.1
 
-  vite@7.3.1(@types/node@24.12.0)(tsx@4.21.0):
+  vite@7.3.1(@types/node@24.13.2)(tsx@4.22.4):
     dependencies:
-      esbuild: 0.27.5
+      esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
-      postcss: 8.5.8
-      rollup: 4.60.1
-      tinyglobby: 0.2.15
+      postcss: 8.5.15
+      rollup: 4.61.1
+      tinyglobby: 0.2.17
     optionalDependencies:
-      '@types/node': 24.12.0
+      '@types/node': 24.13.2
       fsevents: 2.3.3
-      tsx: 4.21.0
+      tsx: 4.22.4
 
-  vitest@4.1.2(@types/node@24.12.0)(vite@7.3.1(@types/node@24.12.0)(tsx@4.21.0)):
+  vitest@4.1.8(@types/node@24.13.2)(@vitest/coverage-v8@4.1.8)(vite@7.3.1(@types/node@24.13.2)(tsx@4.22.4)):
     dependencies:
-      '@vitest/expect': 4.1.2
-      '@vitest/mocker': 4.1.2(vite@7.3.1(@types/node@24.12.0)(tsx@4.21.0))
-      '@vitest/pretty-format': 4.1.2
-      '@vitest/runner': 4.1.2
-      '@vitest/snapshot': 4.1.2
-      '@vitest/spy': 4.1.2
-      '@vitest/utils': 4.1.2
-      es-module-lexer: 2.0.0
+      '@vitest/expect': 4.1.8
+      '@vitest/mocker': 4.1.8(vite@7.3.1(@types/node@24.13.2)(tsx@4.22.4))
+      '@vitest/pretty-format': 4.1.8
+      '@vitest/runner': 4.1.8
+      '@vitest/snapshot': 4.1.8
+      '@vitest/spy': 4.1.8
+      '@vitest/utils': 4.1.8
+      es-module-lexer: 2.1.0
       expect-type: 1.3.0
       magic-string: 0.30.21
-      obug: 2.1.1
+      obug: 2.1.2
       pathe: 2.0.3
       picomatch: 4.0.4
-      std-env: 4.0.0
+      std-env: 4.1.0
       tinybench: 2.9.0
-      tinyexec: 1.0.4
-      tinyglobby: 0.2.15
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vite: 7.3.1(@types/node@24.12.0)(tsx@4.21.0)
+      vite: 7.3.1(@types/node@24.13.2)(tsx@4.22.4)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 24.12.0
+      '@types/node': 24.13.2
+      '@vitest/coverage-v8': 4.1.8(vitest@4.1.8)
     transitivePeerDependencies:
       - msw
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  esbuild: true

--- a/src/all.ts
+++ b/src/all.ts
@@ -1,4 +1,4 @@
-import type { ApiError, DeletableResourceType, ListableResourceType, ListResponse, QueryParamsList, Resource, ResourceUpdate, UpdatableResourceType } from "@commercelayer/sdk"
+import type { ApiError, DeletableResourceType, ListableResourceType, ListResponse, QueryParamsList, QuerySort, Resource, ResourceUpdate, UpdatableResourceType } from "@commercelayer/sdk"
 import { sleep } from "./common"
 import { config } from "./config"
 import CommerceLayerUtils from "./init"
@@ -25,7 +25,7 @@ export const retrieveAll = async <R extends Resource>(resourceType: ListableReso
 	const allParams: QueryParamsList<R> = params || {}
 	allParams.pageNumber = 1
 	allParams.pageSize = config.api.page_max_size
-	allParams.sort = ['id'] as QueryParamsList<R>['sort']
+	allParams.sort = ['id'] as QuerySort<R>
 	if (!allParams.filters) allParams.filters = {}
 
 	do {
@@ -88,7 +88,7 @@ export const updateAll = async <U extends Omit<ResourceUpdate, 'id'>, R extends 
 	const allParams: QueryParamsList<R> = params || {}
 	allParams.pageNumber = 1
 	allParams.pageSize = config.api.page_max_size
-	allParams.sort = ['id'] as QueryParamsList<R>['sort']
+	allParams.sort = ['id'] as QuerySort<R>
 	if (!allParams.filters) allParams.filters = {}
 
 	do {
@@ -161,7 +161,7 @@ export const deleteAll = async <R extends Resource>(resourceType: DeletableResou
 	const allParams: QueryParamsList<R> = params || {}
 	allParams.pageNumber = 1
 	allParams.pageSize = config.api.page_max_size
-	allParams.sort = ['id'] as QueryParamsList<R>['sort']
+	allParams.sort = ['id'] as QuerySort<R>
 	if (!allParams.filters) allParams.filters = {}
 
 	do {

--- a/src/helpers/filter/resources.ts
+++ b/src/helpers/filter/resources.ts
@@ -445,6 +445,7 @@ class ExportFilterFields<M extends Types.FilterMaster> extends ResourceFilterFie
 	get completed_at(): Types.FilterOperator<M> { return this.addField('completed_at') }
 	get interrupted_at(): Types.FilterOperator<M> { return this.addField('interrupted_at') }
 	get records_count(): Types.FilterOperator<M> { return this.addField('records_count') }
+	get processed_count(): Types.FilterOperator<M> { return this.addField('processed_count') }
 	get attachment_url(): Types.FilterOperator<M> { return this.addField('attachment_url') }
 	get errors_log(): Types.FilterOperator<M> { return this.addField('errors_log') }
 	get events(): EventFilterFields<M> { return new EventFilterFields<M>(this.master, this.operator, this.addRelationship('events')) }
@@ -1535,6 +1536,7 @@ class ShippingWeightTierFilterFields<M extends Types.FilterMaster> extends Resou
 	get price_amount_cents(): Types.FilterOperator<M> { return this.addField('price_amount_cents') }
 	get shipping_method(): ShippingMethodFilterFields<M> { return new ShippingMethodFilterFields<M>(this.master, this.operator, this.addRelationship('shipping_method')) }
 	get attachments(): AttachmentFilterFields<M> { return new AttachmentFilterFields<M>(this.master, this.operator, this.addRelationship('attachments')) }
+	get events(): EventFilterFields<M> { return new EventFilterFields<M>(this.master, this.operator, this.addRelationship('events')) }
 }
 
 export type ShippingWeightTierFilter = ShippingWeightTierFilterFields<ShippingWeightTierFilter>
@@ -1828,14 +1830,6 @@ class TransactionFilterFields<M extends Types.FilterMaster> extends ResourceFilt
 export type TransactionFilter = TransactionFilterFields<TransactionFilter>
 
 
-class VersionFilterFields<M extends Types.FilterMaster> extends ResourceFilterFields<M> {
-	get resource_type(): Types.FilterOperator<M> { return this.addField('resource_type') }
-	get resource_id(): Types.FilterOperator<M> { return this.addField('resource_id') }
-}
-
-export type VersionFilter = VersionFilterFields<VersionFilter>
-
-
 class VertexAccountFilterFields<M extends Types.FilterMaster> extends ResourceFilterFields<M> {
 	get name(): Types.FilterOperator<M> { return this.addField('name') }
 	get type(): Types.FilterOperator<M> { return this.addField('type') }
@@ -2014,7 +2008,6 @@ export class FilterHelper {
 	get tax_rules(): TaxRuleFilter { return new TaxRuleFilterFields<TaxRuleFilter>() }
 	get taxjar_accounts(): TaxjarAccountFilter { return new TaxjarAccountFilterFields<TaxjarAccountFilter>() }
 	get transactions(): TransactionFilter { return new TransactionFilterFields<TransactionFilter>() }
-	get versions(): VersionFilter { return new VersionFilterFields<VersionFilter>() }
 	get vertex_accounts(): VertexAccountFilter { return new VertexAccountFilterFields<VertexAccountFilter>() }
 	get voids(): VoidFilter { return new VoidFilterFields<VoidFilter>() }
 	get webhooks(): WebhookFilter { return new WebhookFilterFields<WebhookFilter>() }

--- a/src/helpers/include/resources.ts
+++ b/src/helpers/include/resources.ts
@@ -8,20 +8,17 @@ class AddressInclude extends ResourceInclude {
 	get geocoder(): GeocoderInclude { return new GeocoderInclude(this.include('geocoder'))}
 	get events(): EventInclude { return new EventInclude(this.include('events'))}
 	get tags(): TagInclude { return new TagInclude(this.include('tags'))}
-	get versions(): VersionInclude { return new VersionInclude(this.include('versions'))}
 	get event_stores(): EventStoreInclude { return new EventStoreInclude(this.include('event_stores'))}
 }
 
 
 class AdjustmentInclude extends ResourceInclude {
-	get versions(): VersionInclude { return new VersionInclude(this.include('versions'))}
 	get event_stores(): EventStoreInclude { return new EventStoreInclude(this.include('event_stores'))}
 }
 
 
 class AdyenGatewayInclude extends ResourceInclude {
 	get payment_methods(): PaymentMethodInclude { return new PaymentMethodInclude(this.include('payment_methods'))}
-	get versions(): VersionInclude { return new VersionInclude(this.include('versions'))}
 	get event_stores(): EventStoreInclude { return new EventStoreInclude(this.include('event_stores'))}
 	get adyen_payments(): AdyenPaymentInclude { return new AdyenPaymentInclude(this.include('adyen_payments'))}
 }
@@ -30,7 +27,6 @@ class AdyenGatewayInclude extends ResourceInclude {
 class AdyenPaymentInclude extends ResourceInclude {
 	get order(): OrderInclude { return new OrderInclude(this.include('order'))}
 	get payment_gateway(): PaymentGatewayInclude { return new PaymentGatewayInclude(this.include('payment_gateway'))}
-	get versions(): VersionInclude { return new VersionInclude(this.include('versions'))}
 	get event_stores(): EventStoreInclude { return new EventStoreInclude(this.include('event_stores'))}
 }
 
@@ -48,7 +44,6 @@ class AuthorizationInclude extends ResourceInclude {
 	get order(): OrderInclude { return new OrderInclude(this.include('order'))}
 	get attachments(): AttachmentInclude { return new AttachmentInclude(this.include('attachments'))}
 	get events(): EventInclude { return new EventInclude(this.include('events'))}
-	get versions(): VersionInclude { return new VersionInclude(this.include('versions'))}
 	get event_stores(): EventStoreInclude { return new EventStoreInclude(this.include('event_stores'))}
 	get captures(): CaptureInclude { return new CaptureInclude(this.include('captures'))}
 	get voids(): VoidInclude { return new VoidInclude(this.include('voids'))}
@@ -59,7 +54,6 @@ class AvalaraAccountInclude extends ResourceInclude {
 	get markets(): MarketInclude { return new MarketInclude(this.include('markets'))}
 	get attachments(): AttachmentInclude { return new AttachmentInclude(this.include('attachments'))}
 	get events(): EventInclude { return new EventInclude(this.include('events'))}
-	get versions(): VersionInclude { return new VersionInclude(this.include('versions'))}
 	get event_stores(): EventStoreInclude { return new EventStoreInclude(this.include('event_stores'))}
 	get tax_categories(): TaxCategoryInclude { return new TaxCategoryInclude(this.include('tax_categories'))}
 }
@@ -67,7 +61,6 @@ class AvalaraAccountInclude extends ResourceInclude {
 
 class AxerveGatewayInclude extends ResourceInclude {
 	get payment_methods(): PaymentMethodInclude { return new PaymentMethodInclude(this.include('payment_methods'))}
-	get versions(): VersionInclude { return new VersionInclude(this.include('versions'))}
 	get event_stores(): EventStoreInclude { return new EventStoreInclude(this.include('event_stores'))}
 	get axerve_payments(): AxervePaymentInclude { return new AxervePaymentInclude(this.include('axerve_payments'))}
 }
@@ -76,7 +69,6 @@ class AxerveGatewayInclude extends ResourceInclude {
 class AxervePaymentInclude extends ResourceInclude {
 	get order(): OrderInclude { return new OrderInclude(this.include('order'))}
 	get payment_gateway(): PaymentGatewayInclude { return new PaymentGatewayInclude(this.include('payment_gateway'))}
-	get versions(): VersionInclude { return new VersionInclude(this.include('versions'))}
 	get event_stores(): EventStoreInclude { return new EventStoreInclude(this.include('event_stores'))}
 }
 
@@ -84,7 +76,6 @@ class AxervePaymentInclude extends ResourceInclude {
 class BillingInfoValidationRuleInclude extends ResourceInclude {
 	get market(): MarketInclude { return new MarketInclude(this.include('market'))}
 	get attachments(): AttachmentInclude { return new AttachmentInclude(this.include('attachments'))}
-	get versions(): VersionInclude { return new VersionInclude(this.include('versions'))}
 	get event_stores(): EventStoreInclude { return new EventStoreInclude(this.include('event_stores'))}
 }
 
@@ -99,7 +90,6 @@ class BingGeocoderInclude extends ResourceInclude {
 
 class BraintreeGatewayInclude extends ResourceInclude {
 	get payment_methods(): PaymentMethodInclude { return new PaymentMethodInclude(this.include('payment_methods'))}
-	get versions(): VersionInclude { return new VersionInclude(this.include('versions'))}
 	get event_stores(): EventStoreInclude { return new EventStoreInclude(this.include('event_stores'))}
 	get braintree_payments(): BraintreePaymentInclude { return new BraintreePaymentInclude(this.include('braintree_payments'))}
 }
@@ -108,7 +98,6 @@ class BraintreeGatewayInclude extends ResourceInclude {
 class BraintreePaymentInclude extends ResourceInclude {
 	get order(): OrderInclude { return new OrderInclude(this.include('order'))}
 	get payment_gateway(): PaymentGatewayInclude { return new PaymentGatewayInclude(this.include('payment_gateway'))}
-	get versions(): VersionInclude { return new VersionInclude(this.include('versions'))}
 	get event_stores(): EventStoreInclude { return new EventStoreInclude(this.include('event_stores'))}
 }
 
@@ -120,7 +109,6 @@ class BundleInclude extends ResourceInclude {
 	get attachments(): AttachmentInclude { return new AttachmentInclude(this.include('attachments'))}
 	get events(): EventInclude { return new EventInclude(this.include('events'))}
 	get tags(): TagInclude { return new TagInclude(this.include('tags'))}
-	get versions(): VersionInclude { return new VersionInclude(this.include('versions'))}
 	get event_stores(): EventStoreInclude { return new EventStoreInclude(this.include('event_stores'))}
 }
 
@@ -137,7 +125,6 @@ class BuyXPayYPromotionInclude extends ResourceInclude {
 	get attachments(): AttachmentInclude { return new AttachmentInclude(this.include('attachments'))}
 	get events(): EventInclude { return new EventInclude(this.include('events'))}
 	get tags(): TagInclude { return new TagInclude(this.include('tags'))}
-	get versions(): VersionInclude { return new VersionInclude(this.include('versions'))}
 	get event_stores(): EventStoreInclude { return new EventStoreInclude(this.include('event_stores'))}
 	get skus(): SkuInclude { return new SkuInclude(this.include('skus'))}
 }
@@ -147,7 +134,6 @@ class CaptureInclude extends ResourceInclude {
 	get order(): OrderInclude { return new OrderInclude(this.include('order'))}
 	get attachments(): AttachmentInclude { return new AttachmentInclude(this.include('attachments'))}
 	get events(): EventInclude { return new EventInclude(this.include('events'))}
-	get versions(): VersionInclude { return new VersionInclude(this.include('versions'))}
 	get event_stores(): EventStoreInclude { return new EventStoreInclude(this.include('event_stores'))}
 	get reference_authorization(): AuthorizationInclude { return new AuthorizationInclude(this.include('reference_authorization'))}
 	get refunds(): RefundInclude { return new RefundInclude(this.include('refunds'))}
@@ -158,14 +144,12 @@ class CaptureInclude extends ResourceInclude {
 class CarrierAccountInclude extends ResourceInclude {
 	get market(): MarketInclude { return new MarketInclude(this.include('market'))}
 	get attachments(): AttachmentInclude { return new AttachmentInclude(this.include('attachments'))}
-	get versions(): VersionInclude { return new VersionInclude(this.include('versions'))}
 	get event_stores(): EventStoreInclude { return new EventStoreInclude(this.include('event_stores'))}
 }
 
 
 class CheckoutComGatewayInclude extends ResourceInclude {
 	get payment_methods(): PaymentMethodInclude { return new PaymentMethodInclude(this.include('payment_methods'))}
-	get versions(): VersionInclude { return new VersionInclude(this.include('versions'))}
 	get event_stores(): EventStoreInclude { return new EventStoreInclude(this.include('event_stores'))}
 	get checkout_com_payments(): CheckoutComPaymentInclude { return new CheckoutComPaymentInclude(this.include('checkout_com_payments'))}
 }
@@ -174,14 +158,12 @@ class CheckoutComGatewayInclude extends ResourceInclude {
 class CheckoutComPaymentInclude extends ResourceInclude {
 	get order(): OrderInclude { return new OrderInclude(this.include('order'))}
 	get payment_gateway(): PaymentGatewayInclude { return new PaymentGatewayInclude(this.include('payment_gateway'))}
-	get versions(): VersionInclude { return new VersionInclude(this.include('versions'))}
 	get event_stores(): EventStoreInclude { return new EventStoreInclude(this.include('event_stores'))}
 }
 
 
 class CleanupInclude extends ResourceInclude {
 	get events(): EventInclude { return new EventInclude(this.include('events'))}
-	get versions(): VersionInclude { return new VersionInclude(this.include('versions'))}
 	get event_stores(): EventStoreInclude { return new EventStoreInclude(this.include('event_stores'))}
 }
 
@@ -191,14 +173,12 @@ class CouponInclude extends ResourceInclude {
 	get coupon_recipient(): CouponRecipientInclude { return new CouponRecipientInclude(this.include('coupon_recipient'))}
 	get events(): EventInclude { return new EventInclude(this.include('events'))}
 	get tags(): TagInclude { return new TagInclude(this.include('tags'))}
-	get versions(): VersionInclude { return new VersionInclude(this.include('versions'))}
 	get event_stores(): EventStoreInclude { return new EventStoreInclude(this.include('event_stores'))}
 }
 
 
 class CouponCodesPromotionRuleInclude extends ResourceInclude {
 	get promotion(): PromotionInclude { return new PromotionInclude(this.include('promotion'))} // polymorphic
-	get versions(): VersionInclude { return new VersionInclude(this.include('versions'))}
 	get event_stores(): EventStoreInclude { return new EventStoreInclude(this.include('event_stores'))}
 	get coupons(): CouponInclude { return new CouponInclude(this.include('coupons'))}
 }
@@ -208,13 +188,11 @@ class CouponRecipientInclude extends ResourceInclude {
 	get customer(): CustomerInclude { return new CustomerInclude(this.include('customer'))}
 	get event_stores(): EventStoreInclude { return new EventStoreInclude(this.include('event_stores'))}
 	get attachments(): AttachmentInclude { return new AttachmentInclude(this.include('attachments'))}
-	get versions(): VersionInclude { return new VersionInclude(this.include('versions'))}
 }
 
 
 class CustomPromotionRuleInclude extends ResourceInclude {
 	get promotion(): PromotionInclude { return new PromotionInclude(this.include('promotion'))} // polymorphic
-	get versions(): VersionInclude { return new VersionInclude(this.include('versions'))}
 	get event_stores(): EventStoreInclude { return new EventStoreInclude(this.include('event_stores'))}
 }
 
@@ -242,7 +220,6 @@ class CustomerAddressInclude extends ResourceInclude {
 	get customer(): CustomerInclude { return new CustomerInclude(this.include('customer'))}
 	get address(): AddressInclude { return new AddressInclude(this.include('address'))}
 	get events(): EventInclude { return new EventInclude(this.include('events'))}
-	get versions(): VersionInclude { return new VersionInclude(this.include('versions'))}
 	get event_stores(): EventStoreInclude { return new EventStoreInclude(this.include('event_stores'))}
 }
 
@@ -251,7 +228,6 @@ class CustomerGroupInclude extends ResourceInclude {
 	get customers(): CustomerInclude { return new CustomerInclude(this.include('customers'))}
 	get markets(): MarketInclude { return new MarketInclude(this.include('markets'))}
 	get attachments(): AttachmentInclude { return new AttachmentInclude(this.include('attachments'))}
-	get versions(): VersionInclude { return new VersionInclude(this.include('versions'))}
 	get event_stores(): EventStoreInclude { return new EventStoreInclude(this.include('event_stores'))}
 }
 
@@ -266,7 +242,6 @@ class CustomerPasswordResetInclude extends ResourceInclude {
 class CustomerPaymentSourceInclude extends ResourceInclude {
 	get customer(): CustomerInclude { return new CustomerInclude(this.include('customer'))}
 	get payment_method(): PaymentMethodInclude { return new PaymentMethodInclude(this.include('payment_method'))}
-	get versions(): VersionInclude { return new VersionInclude(this.include('versions'))}
 	get event_stores(): EventStoreInclude { return new EventStoreInclude(this.include('event_stores'))}
 }
 
@@ -274,7 +249,6 @@ class CustomerPaymentSourceInclude extends ResourceInclude {
 class CustomerSubscriptionInclude extends ResourceInclude {
 	get customer(): CustomerInclude { return new CustomerInclude(this.include('customer'))}
 	get events(): EventInclude { return new EventInclude(this.include('events'))}
-	get versions(): VersionInclude { return new VersionInclude(this.include('versions'))}
 	get event_stores(): EventStoreInclude { return new EventStoreInclude(this.include('event_stores'))}
 }
 
@@ -283,7 +257,6 @@ class DeliveryLeadTimeInclude extends ResourceInclude {
 	get stock_location(): StockLocationInclude { return new StockLocationInclude(this.include('stock_location'))}
 	get shipping_method(): ShippingMethodInclude { return new ShippingMethodInclude(this.include('shipping_method'))}
 	get attachments(): AttachmentInclude { return new AttachmentInclude(this.include('attachments'))}
-	get versions(): VersionInclude { return new VersionInclude(this.include('versions'))}
 	get event_stores(): EventStoreInclude { return new EventStoreInclude(this.include('event_stores'))}
 }
 
@@ -292,7 +265,6 @@ class DiscountEngineInclude extends ResourceInclude {
 	get markets(): MarketInclude { return new MarketInclude(this.include('markets'))}
 	get discount_engine_items(): DiscountEngineItemInclude { return new DiscountEngineItemInclude(this.include('discount_engine_items'))}
 	get attachments(): AttachmentInclude { return new AttachmentInclude(this.include('attachments'))}
-	get versions(): VersionInclude { return new VersionInclude(this.include('versions'))}
 	get event_stores(): EventStoreInclude { return new EventStoreInclude(this.include('event_stores'))}
 }
 
@@ -331,14 +303,12 @@ class EventStoreInclude extends ResourceInclude {
 
 class ExportInclude extends ResourceInclude {
 	get events(): EventInclude { return new EventInclude(this.include('events'))}
-	get versions(): VersionInclude { return new VersionInclude(this.include('versions'))}
 	get event_stores(): EventStoreInclude { return new EventStoreInclude(this.include('event_stores'))}
 }
 
 
 class ExternalGatewayInclude extends ResourceInclude {
 	get payment_methods(): PaymentMethodInclude { return new PaymentMethodInclude(this.include('payment_methods'))}
-	get versions(): VersionInclude { return new VersionInclude(this.include('versions'))}
 	get event_stores(): EventStoreInclude { return new EventStoreInclude(this.include('event_stores'))}
 	get external_payments(): ExternalPaymentInclude { return new ExternalPaymentInclude(this.include('external_payments'))}
 }
@@ -348,7 +318,6 @@ class ExternalPaymentInclude extends ResourceInclude {
 	get order(): OrderInclude { return new OrderInclude(this.include('order'))}
 	get payment_gateway(): PaymentGatewayInclude { return new PaymentGatewayInclude(this.include('payment_gateway'))}
 	get wallet(): CustomerPaymentSourceInclude { return new CustomerPaymentSourceInclude(this.include('wallet'))}
-	get versions(): VersionInclude { return new VersionInclude(this.include('versions'))}
 	get event_stores(): EventStoreInclude { return new EventStoreInclude(this.include('event_stores'))}
 }
 
@@ -365,7 +334,6 @@ class ExternalPromotionInclude extends ResourceInclude {
 	get attachments(): AttachmentInclude { return new AttachmentInclude(this.include('attachments'))}
 	get events(): EventInclude { return new EventInclude(this.include('events'))}
 	get tags(): TagInclude { return new TagInclude(this.include('tags'))}
-	get versions(): VersionInclude { return new VersionInclude(this.include('versions'))}
 	get event_stores(): EventStoreInclude { return new EventStoreInclude(this.include('event_stores'))}
 	get skus(): SkuInclude { return new SkuInclude(this.include('skus'))}
 }
@@ -375,7 +343,6 @@ class ExternalTaxCalculatorInclude extends ResourceInclude {
 	get markets(): MarketInclude { return new MarketInclude(this.include('markets'))}
 	get attachments(): AttachmentInclude { return new AttachmentInclude(this.include('attachments'))}
 	get events(): EventInclude { return new EventInclude(this.include('events'))}
-	get versions(): VersionInclude { return new VersionInclude(this.include('versions'))}
 	get event_stores(): EventStoreInclude { return new EventStoreInclude(this.include('event_stores'))}
 }
 
@@ -392,7 +359,6 @@ class FixedAmountPromotionInclude extends ResourceInclude {
 	get attachments(): AttachmentInclude { return new AttachmentInclude(this.include('attachments'))}
 	get events(): EventInclude { return new EventInclude(this.include('events'))}
 	get tags(): TagInclude { return new TagInclude(this.include('tags'))}
-	get versions(): VersionInclude { return new VersionInclude(this.include('versions'))}
 	get event_stores(): EventStoreInclude { return new EventStoreInclude(this.include('event_stores'))}
 	get skus(): SkuInclude { return new SkuInclude(this.include('skus'))}
 }
@@ -410,7 +376,6 @@ class FixedPricePromotionInclude extends ResourceInclude {
 	get attachments(): AttachmentInclude { return new AttachmentInclude(this.include('attachments'))}
 	get events(): EventInclude { return new EventInclude(this.include('events'))}
 	get tags(): TagInclude { return new TagInclude(this.include('tags'))}
-	get versions(): VersionInclude { return new VersionInclude(this.include('versions'))}
 	get event_stores(): EventStoreInclude { return new EventStoreInclude(this.include('event_stores'))}
 	get skus(): SkuInclude { return new SkuInclude(this.include('skus'))}
 }
@@ -422,7 +387,6 @@ class FlexPromotionInclude extends ResourceInclude {
 	get attachments(): AttachmentInclude { return new AttachmentInclude(this.include('attachments'))}
 	get events(): EventInclude { return new EventInclude(this.include('events'))}
 	get tags(): TagInclude { return new TagInclude(this.include('tags'))}
-	get versions(): VersionInclude { return new VersionInclude(this.include('versions'))}
 	get event_stores(): EventStoreInclude { return new EventStoreInclude(this.include('event_stores'))}
 }
 
@@ -439,7 +403,6 @@ class FreeGiftPromotionInclude extends ResourceInclude {
 	get attachments(): AttachmentInclude { return new AttachmentInclude(this.include('attachments'))}
 	get events(): EventInclude { return new EventInclude(this.include('events'))}
 	get tags(): TagInclude { return new TagInclude(this.include('tags'))}
-	get versions(): VersionInclude { return new VersionInclude(this.include('versions'))}
 	get event_stores(): EventStoreInclude { return new EventStoreInclude(this.include('event_stores'))}
 	get skus(): SkuInclude { return new SkuInclude(this.include('skus'))}
 }
@@ -457,7 +420,6 @@ class FreeShippingPromotionInclude extends ResourceInclude {
 	get attachments(): AttachmentInclude { return new AttachmentInclude(this.include('attachments'))}
 	get events(): EventInclude { return new EventInclude(this.include('events'))}
 	get tags(): TagInclude { return new TagInclude(this.include('tags'))}
-	get versions(): VersionInclude { return new VersionInclude(this.include('versions'))}
 	get event_stores(): EventStoreInclude { return new EventStoreInclude(this.include('event_stores'))}
 }
 
@@ -476,7 +438,6 @@ class GiftCardInclude extends ResourceInclude {
 	get attachments(): AttachmentInclude { return new AttachmentInclude(this.include('attachments'))}
 	get events(): EventInclude { return new EventInclude(this.include('events'))}
 	get tags(): TagInclude { return new TagInclude(this.include('tags'))}
-	get versions(): VersionInclude { return new VersionInclude(this.include('versions'))}
 	get event_stores(): EventStoreInclude { return new EventStoreInclude(this.include('event_stores'))}
 }
 
@@ -485,7 +446,6 @@ class GiftCardRecipientInclude extends ResourceInclude {
 	get customer(): CustomerInclude { return new CustomerInclude(this.include('customer'))}
 	get event_stores(): EventStoreInclude { return new EventStoreInclude(this.include('event_stores'))}
 	get attachments(): AttachmentInclude { return new AttachmentInclude(this.include('attachments'))}
-	get versions(): VersionInclude { return new VersionInclude(this.include('versions'))}
 }
 
 
@@ -508,7 +468,6 @@ class InStockSubscriptionInclude extends ResourceInclude {
 	get customer(): CustomerInclude { return new CustomerInclude(this.include('customer'))}
 	get sku(): SkuInclude { return new SkuInclude(this.include('sku'))}
 	get events(): EventInclude { return new EventInclude(this.include('events'))}
-	get versions(): VersionInclude { return new VersionInclude(this.include('versions'))}
 	get event_stores(): EventStoreInclude { return new EventStoreInclude(this.include('event_stores'))}
 }
 
@@ -517,7 +476,6 @@ class InventoryModelInclude extends ResourceInclude {
 	get inventory_stock_locations(): InventoryStockLocationInclude { return new InventoryStockLocationInclude(this.include('inventory_stock_locations'))}
 	get inventory_return_locations(): InventoryReturnLocationInclude { return new InventoryReturnLocationInclude(this.include('inventory_return_locations'))}
 	get attachments(): AttachmentInclude { return new AttachmentInclude(this.include('attachments'))}
-	get versions(): VersionInclude { return new VersionInclude(this.include('versions'))}
 	get event_stores(): EventStoreInclude { return new EventStoreInclude(this.include('event_stores'))}
 }
 
@@ -525,7 +483,6 @@ class InventoryModelInclude extends ResourceInclude {
 class InventoryReturnLocationInclude extends ResourceInclude {
 	get stock_location(): StockLocationInclude { return new StockLocationInclude(this.include('stock_location'))}
 	get inventory_model(): InventoryModelInclude { return new InventoryModelInclude(this.include('inventory_model'))}
-	get versions(): VersionInclude { return new VersionInclude(this.include('versions'))}
 	get event_stores(): EventStoreInclude { return new EventStoreInclude(this.include('event_stores'))}
 }
 
@@ -533,14 +490,12 @@ class InventoryReturnLocationInclude extends ResourceInclude {
 class InventoryStockLocationInclude extends ResourceInclude {
 	get stock_location(): StockLocationInclude { return new StockLocationInclude(this.include('stock_location'))}
 	get inventory_model(): InventoryModelInclude { return new InventoryModelInclude(this.include('inventory_model'))}
-	get versions(): VersionInclude { return new VersionInclude(this.include('versions'))}
 	get event_stores(): EventStoreInclude { return new EventStoreInclude(this.include('event_stores'))}
 }
 
 
 class KlarnaGatewayInclude extends ResourceInclude {
 	get payment_methods(): PaymentMethodInclude { return new PaymentMethodInclude(this.include('payment_methods'))}
-	get versions(): VersionInclude { return new VersionInclude(this.include('versions'))}
 	get event_stores(): EventStoreInclude { return new EventStoreInclude(this.include('event_stores'))}
 	get klarna_payments(): KlarnaPaymentInclude { return new KlarnaPaymentInclude(this.include('klarna_payments'))}
 }
@@ -549,7 +504,6 @@ class KlarnaGatewayInclude extends ResourceInclude {
 class KlarnaPaymentInclude extends ResourceInclude {
 	get order(): OrderInclude { return new OrderInclude(this.include('order'))}
 	get payment_gateway(): PaymentGatewayInclude { return new PaymentGatewayInclude(this.include('payment_gateway'))}
-	get versions(): VersionInclude { return new VersionInclude(this.include('versions'))}
 	get event_stores(): EventStoreInclude { return new EventStoreInclude(this.include('event_stores'))}
 }
 
@@ -592,7 +546,6 @@ class LinkInclude extends ResourceInclude {
 
 class ManualGatewayInclude extends ResourceInclude {
 	get payment_methods(): PaymentMethodInclude { return new PaymentMethodInclude(this.include('payment_methods'))}
-	get versions(): VersionInclude { return new VersionInclude(this.include('versions'))}
 	get event_stores(): EventStoreInclude { return new EventStoreInclude(this.include('event_stores'))}
 }
 
@@ -601,7 +554,6 @@ class ManualTaxCalculatorInclude extends ResourceInclude {
 	get markets(): MarketInclude { return new MarketInclude(this.include('markets'))}
 	get attachments(): AttachmentInclude { return new AttachmentInclude(this.include('attachments'))}
 	get events(): EventInclude { return new EventInclude(this.include('events'))}
-	get versions(): VersionInclude { return new VersionInclude(this.include('versions'))}
 	get event_stores(): EventStoreInclude { return new EventStoreInclude(this.include('event_stores'))}
 	get tax_rules(): TaxRuleInclude { return new TaxRuleInclude(this.include('tax_rules'))}
 }
@@ -623,7 +575,6 @@ class MarketInclude extends ResourceInclude {
 	get price_list_schedulers(): PriceListSchedulerInclude { return new PriceListSchedulerInclude(this.include('price_list_schedulers'))}
 	get order_validation_rules(): OrderValidationRuleInclude { return new OrderValidationRuleInclude(this.include('order_validation_rules'))} // polymorphic
 	get attachments(): AttachmentInclude { return new AttachmentInclude(this.include('attachments'))}
-	get versions(): VersionInclude { return new VersionInclude(this.include('versions'))}
 	get event_stores(): EventStoreInclude { return new EventStoreInclude(this.include('event_stores'))}
 }
 
@@ -631,7 +582,6 @@ class MarketInclude extends ResourceInclude {
 class MerchantInclude extends ResourceInclude {
 	get address(): AddressInclude { return new AddressInclude(this.include('address'))}
 	get attachments(): AttachmentInclude { return new AttachmentInclude(this.include('attachments'))}
-	get versions(): VersionInclude { return new VersionInclude(this.include('versions'))}
 	get event_stores(): EventStoreInclude { return new EventStoreInclude(this.include('event_stores'))}
 }
 
@@ -679,14 +629,12 @@ class OrderInclude extends ResourceInclude {
 	get resource_errors(): ResourceErrorInclude { return new ResourceErrorInclude(this.include('resource_errors'))}
 	get events(): EventInclude { return new EventInclude(this.include('events'))}
 	get tags(): TagInclude { return new TagInclude(this.include('tags'))}
-	get versions(): VersionInclude { return new VersionInclude(this.include('versions'))}
 	get event_stores(): EventStoreInclude { return new EventStoreInclude(this.include('event_stores'))}
 }
 
 
 class OrderAmountPromotionRuleInclude extends ResourceInclude {
 	get promotion(): PromotionInclude { return new PromotionInclude(this.include('promotion'))} // polymorphic
-	get versions(): VersionInclude { return new VersionInclude(this.include('versions'))}
 	get event_stores(): EventStoreInclude { return new EventStoreInclude(this.include('event_stores'))}
 }
 
@@ -721,7 +669,6 @@ class OrderSubscriptionInclude extends ResourceInclude {
 	get orders(): OrderInclude { return new OrderInclude(this.include('orders'))}
 	get events(): EventInclude { return new EventInclude(this.include('events'))}
 	get tags(): TagInclude { return new TagInclude(this.include('tags'))}
-	get versions(): VersionInclude { return new VersionInclude(this.include('versions'))}
 	get event_stores(): EventStoreInclude { return new EventStoreInclude(this.include('event_stores'))}
 }
 
@@ -739,7 +686,6 @@ class OrderSubscriptionItemInclude extends ResourceInclude {
 class OrderValidationRuleInclude extends ResourceInclude {
 	get market(): MarketInclude { return new MarketInclude(this.include('market'))}
 	get attachments(): AttachmentInclude { return new AttachmentInclude(this.include('attachments'))}
-	get versions(): VersionInclude { return new VersionInclude(this.include('versions'))}
 	get event_stores(): EventStoreInclude { return new EventStoreInclude(this.include('event_stores'))}
 }
 
@@ -753,7 +699,6 @@ class PackageInclude extends ResourceInclude {
 	get stock_location(): StockLocationInclude { return new StockLocationInclude(this.include('stock_location'))}
 	get parcels(): ParcelInclude { return new ParcelInclude(this.include('parcels'))}
 	get attachments(): AttachmentInclude { return new AttachmentInclude(this.include('attachments'))}
-	get versions(): VersionInclude { return new VersionInclude(this.include('versions'))}
 	get event_stores(): EventStoreInclude { return new EventStoreInclude(this.include('event_stores'))}
 }
 
@@ -764,7 +709,6 @@ class ParcelInclude extends ResourceInclude {
 	get parcel_line_items(): ParcelLineItemInclude { return new ParcelLineItemInclude(this.include('parcel_line_items'))}
 	get attachments(): AttachmentInclude { return new AttachmentInclude(this.include('attachments'))}
 	get events(): EventInclude { return new EventInclude(this.include('events'))}
-	get versions(): VersionInclude { return new VersionInclude(this.include('versions'))}
 	get event_stores(): EventStoreInclude { return new EventStoreInclude(this.include('event_stores'))}
 }
 
@@ -773,14 +717,12 @@ class ParcelLineItemInclude extends ResourceInclude {
 	get parcel(): ParcelInclude { return new ParcelInclude(this.include('parcel'))}
 	get stock_line_item(): StockLineItemInclude { return new StockLineItemInclude(this.include('stock_line_item'))}
 	get shipment_line_item(): ShipmentLineItemInclude { return new ShipmentLineItemInclude(this.include('shipment_line_item'))}
-	get versions(): VersionInclude { return new VersionInclude(this.include('versions'))}
 	get event_stores(): EventStoreInclude { return new EventStoreInclude(this.include('event_stores'))}
 }
 
 
 class PaymentGatewayInclude extends ResourceInclude {
 	get payment_methods(): PaymentMethodInclude { return new PaymentMethodInclude(this.include('payment_methods'))}
-	get versions(): VersionInclude { return new VersionInclude(this.include('versions'))}
 	get event_stores(): EventStoreInclude { return new EventStoreInclude(this.include('event_stores'))}
 }
 
@@ -790,7 +732,6 @@ class PaymentMethodInclude extends ResourceInclude {
 	get payment_gateway(): PaymentGatewayInclude { return new PaymentGatewayInclude(this.include('payment_gateway'))}
 	get store(): StoreInclude { return new StoreInclude(this.include('store'))}
 	get attachments(): AttachmentInclude { return new AttachmentInclude(this.include('attachments'))}
-	get versions(): VersionInclude { return new VersionInclude(this.include('versions'))}
 	get event_stores(): EventStoreInclude { return new EventStoreInclude(this.include('event_stores'))}
 }
 
@@ -804,7 +745,6 @@ class PaymentOptionInclude extends ResourceInclude {
 
 class PaypalGatewayInclude extends ResourceInclude {
 	get payment_methods(): PaymentMethodInclude { return new PaymentMethodInclude(this.include('payment_methods'))}
-	get versions(): VersionInclude { return new VersionInclude(this.include('versions'))}
 	get event_stores(): EventStoreInclude { return new EventStoreInclude(this.include('event_stores'))}
 	get paypal_payments(): PaypalPaymentInclude { return new PaypalPaymentInclude(this.include('paypal_payments'))}
 }
@@ -813,7 +753,6 @@ class PaypalGatewayInclude extends ResourceInclude {
 class PaypalPaymentInclude extends ResourceInclude {
 	get order(): OrderInclude { return new OrderInclude(this.include('order'))}
 	get payment_gateway(): PaymentGatewayInclude { return new PaymentGatewayInclude(this.include('payment_gateway'))}
-	get versions(): VersionInclude { return new VersionInclude(this.include('versions'))}
 	get event_stores(): EventStoreInclude { return new EventStoreInclude(this.include('event_stores'))}
 }
 
@@ -830,7 +769,6 @@ class PercentageDiscountPromotionInclude extends ResourceInclude {
 	get attachments(): AttachmentInclude { return new AttachmentInclude(this.include('attachments'))}
 	get events(): EventInclude { return new EventInclude(this.include('events'))}
 	get tags(): TagInclude { return new TagInclude(this.include('tags'))}
-	get versions(): VersionInclude { return new VersionInclude(this.include('versions'))}
 	get event_stores(): EventStoreInclude { return new EventStoreInclude(this.include('event_stores'))}
 	get skus(): SkuInclude { return new SkuInclude(this.include('skus'))}
 }
@@ -851,7 +789,6 @@ class PriceInclude extends ResourceInclude {
 	get price_volume_tiers(): PriceVolumeTierInclude { return new PriceVolumeTierInclude(this.include('price_volume_tiers'))}
 	get price_frequency_tiers(): PriceFrequencyTierInclude { return new PriceFrequencyTierInclude(this.include('price_frequency_tiers'))}
 	get attachments(): AttachmentInclude { return new AttachmentInclude(this.include('attachments'))}
-	get versions(): VersionInclude { return new VersionInclude(this.include('versions'))}
 	get jwt_customer(): CustomerInclude { return new CustomerInclude(this.include('jwt_customer'))}
 	get jwt_markets(): MarketInclude { return new MarketInclude(this.include('jwt_markets'))}
 	get jwt_stock_locations(): StockLocationInclude { return new StockLocationInclude(this.include('jwt_stock_locations'))}
@@ -862,7 +799,6 @@ class PriceInclude extends ResourceInclude {
 class PriceFrequencyTierInclude extends ResourceInclude {
 	get price(): PriceInclude { return new PriceInclude(this.include('price'))}
 	get attachments(): AttachmentInclude { return new AttachmentInclude(this.include('attachments'))}
-	get versions(): VersionInclude { return new VersionInclude(this.include('versions'))}
 	get event_stores(): EventStoreInclude { return new EventStoreInclude(this.include('event_stores'))}
 	get events(): EventInclude { return new EventInclude(this.include('events'))}
 }
@@ -872,7 +808,6 @@ class PriceListInclude extends ResourceInclude {
 	get prices(): PriceInclude { return new PriceInclude(this.include('prices'))}
 	get price_list_schedulers(): PriceListSchedulerInclude { return new PriceListSchedulerInclude(this.include('price_list_schedulers'))}
 	get attachments(): AttachmentInclude { return new AttachmentInclude(this.include('attachments'))}
-	get versions(): VersionInclude { return new VersionInclude(this.include('versions'))}
 	get event_stores(): EventStoreInclude { return new EventStoreInclude(this.include('event_stores'))}
 }
 
@@ -881,7 +816,6 @@ class PriceListSchedulerInclude extends ResourceInclude {
 	get market(): MarketInclude { return new MarketInclude(this.include('market'))}
 	get price_list(): PriceListInclude { return new PriceListInclude(this.include('price_list'))}
 	get events(): EventInclude { return new EventInclude(this.include('events'))}
-	get versions(): VersionInclude { return new VersionInclude(this.include('versions'))}
 	get event_stores(): EventStoreInclude { return new EventStoreInclude(this.include('event_stores'))}
 }
 
@@ -889,7 +823,6 @@ class PriceListSchedulerInclude extends ResourceInclude {
 class PriceTierInclude extends ResourceInclude {
 	get price(): PriceInclude { return new PriceInclude(this.include('price'))}
 	get attachments(): AttachmentInclude { return new AttachmentInclude(this.include('attachments'))}
-	get versions(): VersionInclude { return new VersionInclude(this.include('versions'))}
 	get event_stores(): EventStoreInclude { return new EventStoreInclude(this.include('event_stores'))}
 }
 
@@ -897,7 +830,6 @@ class PriceTierInclude extends ResourceInclude {
 class PriceVolumeTierInclude extends ResourceInclude {
 	get price(): PriceInclude { return new PriceInclude(this.include('price'))}
 	get attachments(): AttachmentInclude { return new AttachmentInclude(this.include('attachments'))}
-	get versions(): VersionInclude { return new VersionInclude(this.include('versions'))}
 	get event_stores(): EventStoreInclude { return new EventStoreInclude(this.include('event_stores'))}
 	get events(): EventInclude { return new EventInclude(this.include('events'))}
 }
@@ -915,14 +847,12 @@ class PromotionInclude extends ResourceInclude {
 	get attachments(): AttachmentInclude { return new AttachmentInclude(this.include('attachments'))}
 	get events(): EventInclude { return new EventInclude(this.include('events'))}
 	get tags(): TagInclude { return new TagInclude(this.include('tags'))}
-	get versions(): VersionInclude { return new VersionInclude(this.include('versions'))}
 	get event_stores(): EventStoreInclude { return new EventStoreInclude(this.include('event_stores'))}
 }
 
 
 class PromotionRuleInclude extends ResourceInclude {
 	get promotion(): PromotionInclude { return new PromotionInclude(this.include('promotion'))} // polymorphic
-	get versions(): VersionInclude { return new VersionInclude(this.include('versions'))}
 	get event_stores(): EventStoreInclude { return new EventStoreInclude(this.include('event_stores'))}
 }
 
@@ -940,7 +870,6 @@ class RefundInclude extends ResourceInclude {
 	get order(): OrderInclude { return new OrderInclude(this.include('order'))}
 	get attachments(): AttachmentInclude { return new AttachmentInclude(this.include('attachments'))}
 	get events(): EventInclude { return new EventInclude(this.include('events'))}
-	get versions(): VersionInclude { return new VersionInclude(this.include('versions'))}
 	get event_stores(): EventStoreInclude { return new EventStoreInclude(this.include('event_stores'))}
 	get reference_capture(): CaptureInclude { return new CaptureInclude(this.include('reference_capture'))}
 	get return(): ReturnInclude { return new ReturnInclude(this.include('return'))}
@@ -951,7 +880,6 @@ class ReservedStockInclude extends ResourceInclude {
 	get stock_item(): StockItemInclude { return new StockItemInclude(this.include('stock_item'))}
 	get sku(): SkuInclude { return new SkuInclude(this.include('sku'))}
 	get stock_reservations(): StockReservationInclude { return new StockReservationInclude(this.include('stock_reservations'))}
-	get versions(): VersionInclude { return new VersionInclude(this.include('versions'))}
 	get event_stores(): EventStoreInclude { return new EventStoreInclude(this.include('event_stores'))}
 }
 
@@ -974,7 +902,6 @@ class ReturnInclude extends ResourceInclude {
 	get resource_errors(): ResourceErrorInclude { return new ResourceErrorInclude(this.include('resource_errors'))}
 	get events(): EventInclude { return new EventInclude(this.include('events'))}
 	get tags(): TagInclude { return new TagInclude(this.include('tags'))}
-	get versions(): VersionInclude { return new VersionInclude(this.include('versions'))}
 	get event_stores(): EventStoreInclude { return new EventStoreInclude(this.include('event_stores'))}
 }
 
@@ -988,7 +915,6 @@ class ReturnLineItemInclude extends ResourceInclude {
 
 class SatispayGatewayInclude extends ResourceInclude {
 	get payment_methods(): PaymentMethodInclude { return new PaymentMethodInclude(this.include('payment_methods'))}
-	get versions(): VersionInclude { return new VersionInclude(this.include('versions'))}
 	get event_stores(): EventStoreInclude { return new EventStoreInclude(this.include('event_stores'))}
 	get satispay_payments(): SatispayPaymentInclude { return new SatispayPaymentInclude(this.include('satispay_payments'))}
 }
@@ -997,7 +923,6 @@ class SatispayGatewayInclude extends ResourceInclude {
 class SatispayPaymentInclude extends ResourceInclude {
 	get order(): OrderInclude { return new OrderInclude(this.include('order'))}
 	get payment_gateway(): PaymentGatewayInclude { return new PaymentGatewayInclude(this.include('payment_gateway'))}
-	get versions(): VersionInclude { return new VersionInclude(this.include('versions'))}
 	get event_stores(): EventStoreInclude { return new EventStoreInclude(this.include('event_stores'))}
 }
 
@@ -1022,7 +947,6 @@ class ShipmentInclude extends ResourceInclude {
 	get attachments(): AttachmentInclude { return new AttachmentInclude(this.include('attachments'))}
 	get events(): EventInclude { return new EventInclude(this.include('events'))}
 	get tags(): TagInclude { return new TagInclude(this.include('tags'))}
-	get versions(): VersionInclude { return new VersionInclude(this.include('versions'))}
 	get event_stores(): EventStoreInclude { return new EventStoreInclude(this.include('event_stores'))}
 }
 
@@ -1033,7 +957,6 @@ class ShipmentLineItemInclude extends ResourceInclude {
 	get stock_item(): StockItemInclude { return new StockItemInclude(this.include('stock_item'))}
 	get sku(): SkuInclude { return new SkuInclude(this.include('sku'))}
 	get stock_reservation(): StockReservationInclude { return new StockReservationInclude(this.include('stock_reservation'))}
-	get versions(): VersionInclude { return new VersionInclude(this.include('versions'))}
 	get event_stores(): EventStoreInclude { return new EventStoreInclude(this.include('event_stores'))}
 }
 
@@ -1041,7 +964,6 @@ class ShipmentLineItemInclude extends ResourceInclude {
 class ShippingCategoryInclude extends ResourceInclude {
 	get skus(): SkuInclude { return new SkuInclude(this.include('skus'))}
 	get attachments(): AttachmentInclude { return new AttachmentInclude(this.include('attachments'))}
-	get versions(): VersionInclude { return new VersionInclude(this.include('versions'))}
 	get event_stores(): EventStoreInclude { return new EventStoreInclude(this.include('event_stores'))}
 }
 
@@ -1058,7 +980,6 @@ class ShippingMethodInclude extends ResourceInclude {
 	get notifications(): NotificationInclude { return new NotificationInclude(this.include('notifications'))}
 	get events(): EventInclude { return new EventInclude(this.include('events'))}
 	get tags(): TagInclude { return new TagInclude(this.include('tags'))}
-	get versions(): VersionInclude { return new VersionInclude(this.include('versions'))}
 	get event_stores(): EventStoreInclude { return new EventStoreInclude(this.include('event_stores'))}
 }
 
@@ -1066,7 +987,6 @@ class ShippingMethodInclude extends ResourceInclude {
 class ShippingMethodTierInclude extends ResourceInclude {
 	get shipping_method(): ShippingMethodInclude { return new ShippingMethodInclude(this.include('shipping_method'))}
 	get attachments(): AttachmentInclude { return new AttachmentInclude(this.include('attachments'))}
-	get versions(): VersionInclude { return new VersionInclude(this.include('versions'))}
 	get event_stores(): EventStoreInclude { return new EventStoreInclude(this.include('event_stores'))}
 }
 
@@ -1074,14 +994,13 @@ class ShippingMethodTierInclude extends ResourceInclude {
 class ShippingWeightTierInclude extends ResourceInclude {
 	get shipping_method(): ShippingMethodInclude { return new ShippingMethodInclude(this.include('shipping_method'))}
 	get attachments(): AttachmentInclude { return new AttachmentInclude(this.include('attachments'))}
-	get versions(): VersionInclude { return new VersionInclude(this.include('versions'))}
 	get event_stores(): EventStoreInclude { return new EventStoreInclude(this.include('event_stores'))}
+	get events(): EventInclude { return new EventInclude(this.include('events'))}
 }
 
 
 class ShippingZoneInclude extends ResourceInclude {
 	get attachments(): AttachmentInclude { return new AttachmentInclude(this.include('attachments'))}
-	get versions(): VersionInclude { return new VersionInclude(this.include('versions'))}
 	get event_stores(): EventStoreInclude { return new EventStoreInclude(this.include('event_stores'))}
 }
 
@@ -1099,7 +1018,6 @@ class SkuInclude extends ResourceInclude {
 	get links(): LinkInclude { return new LinkInclude(this.include('links'))}
 	get events(): EventInclude { return new EventInclude(this.include('events'))}
 	get tags(): TagInclude { return new TagInclude(this.include('tags'))}
-	get versions(): VersionInclude { return new VersionInclude(this.include('versions'))}
 	get jwt_customer(): CustomerInclude { return new CustomerInclude(this.include('jwt_customer'))}
 	get jwt_markets(): MarketInclude { return new MarketInclude(this.include('jwt_markets'))}
 	get jwt_stock_locations(): StockLocationInclude { return new StockLocationInclude(this.include('jwt_stock_locations'))}
@@ -1114,7 +1032,6 @@ class SkuListInclude extends ResourceInclude {
 	get bundles(): BundleInclude { return new BundleInclude(this.include('bundles'))}
 	get attachments(): AttachmentInclude { return new AttachmentInclude(this.include('attachments'))}
 	get links(): LinkInclude { return new LinkInclude(this.include('links'))}
-	get versions(): VersionInclude { return new VersionInclude(this.include('versions'))}
 	get event_stores(): EventStoreInclude { return new EventStoreInclude(this.include('event_stores'))}
 }
 
@@ -1122,14 +1039,12 @@ class SkuListInclude extends ResourceInclude {
 class SkuListItemInclude extends ResourceInclude {
 	get sku_list(): SkuListInclude { return new SkuListInclude(this.include('sku_list'))}
 	get sku(): SkuInclude { return new SkuInclude(this.include('sku'))}
-	get versions(): VersionInclude { return new VersionInclude(this.include('versions'))}
 	get event_stores(): EventStoreInclude { return new EventStoreInclude(this.include('event_stores'))}
 }
 
 
 class SkuListPromotionRuleInclude extends ResourceInclude {
 	get promotion(): PromotionInclude { return new PromotionInclude(this.include('promotion'))} // polymorphic
-	get versions(): VersionInclude { return new VersionInclude(this.include('versions'))}
 	get event_stores(): EventStoreInclude { return new EventStoreInclude(this.include('event_stores'))}
 	get sku_list(): SkuListInclude { return new SkuListInclude(this.include('sku_list'))}
 	get skus(): SkuInclude { return new SkuInclude(this.include('skus'))}
@@ -1141,7 +1056,6 @@ class SkuOptionInclude extends ResourceInclude {
 	get attachments(): AttachmentInclude { return new AttachmentInclude(this.include('attachments'))}
 	get events(): EventInclude { return new EventInclude(this.include('events'))}
 	get tags(): TagInclude { return new TagInclude(this.include('tags'))}
-	get versions(): VersionInclude { return new VersionInclude(this.include('versions'))}
 	get event_stores(): EventStoreInclude { return new EventStoreInclude(this.include('event_stores'))}
 }
 
@@ -1152,7 +1066,6 @@ class StockItemInclude extends ResourceInclude {
 	get reserved_stock(): ReservedStockInclude { return new ReservedStockInclude(this.include('reserved_stock'))}
 	get stock_reservations(): StockReservationInclude { return new StockReservationInclude(this.include('stock_reservations'))}
 	get attachments(): AttachmentInclude { return new AttachmentInclude(this.include('attachments'))}
-	get versions(): VersionInclude { return new VersionInclude(this.include('versions'))}
 	get event_stores(): EventStoreInclude { return new EventStoreInclude(this.include('event_stores'))}
 }
 
@@ -1163,7 +1076,6 @@ class StockLineItemInclude extends ResourceInclude {
 	get stock_item(): StockItemInclude { return new StockItemInclude(this.include('stock_item'))}
 	get sku(): SkuInclude { return new SkuInclude(this.include('sku'))}
 	get stock_reservation(): StockReservationInclude { return new StockReservationInclude(this.include('stock_reservation'))}
-	get versions(): VersionInclude { return new VersionInclude(this.include('versions'))}
 	get event_stores(): EventStoreInclude { return new EventStoreInclude(this.include('event_stores'))}
 }
 
@@ -1176,7 +1088,6 @@ class StockLocationInclude extends ResourceInclude {
 	get stock_transfers(): StockTransferInclude { return new StockTransferInclude(this.include('stock_transfers'))}
 	get stores(): StoreInclude { return new StoreInclude(this.include('stores'))}
 	get attachments(): AttachmentInclude { return new AttachmentInclude(this.include('attachments'))}
-	get versions(): VersionInclude { return new VersionInclude(this.include('versions'))}
 	get event_stores(): EventStoreInclude { return new EventStoreInclude(this.include('event_stores'))}
 }
 
@@ -1202,7 +1113,6 @@ class StockTransferInclude extends ResourceInclude {
 	get stock_reservation(): StockReservationInclude { return new StockReservationInclude(this.include('stock_reservation'))}
 	get attachments(): AttachmentInclude { return new AttachmentInclude(this.include('attachments'))}
 	get events(): EventInclude { return new EventInclude(this.include('events'))}
-	get versions(): VersionInclude { return new VersionInclude(this.include('versions'))}
 	get event_stores(): EventStoreInclude { return new EventStoreInclude(this.include('event_stores'))}
 }
 
@@ -1214,14 +1124,12 @@ class StoreInclude extends ResourceInclude {
 	get orders(): OrderInclude { return new OrderInclude(this.include('orders'))}
 	get payment_methods(): PaymentMethodInclude { return new PaymentMethodInclude(this.include('payment_methods'))}
 	get events(): EventInclude { return new EventInclude(this.include('events'))}
-	get versions(): VersionInclude { return new VersionInclude(this.include('versions'))}
 	get event_stores(): EventStoreInclude { return new EventStoreInclude(this.include('event_stores'))}
 }
 
 
 class StripeGatewayInclude extends ResourceInclude {
 	get payment_methods(): PaymentMethodInclude { return new PaymentMethodInclude(this.include('payment_methods'))}
-	get versions(): VersionInclude { return new VersionInclude(this.include('versions'))}
 	get event_stores(): EventStoreInclude { return new EventStoreInclude(this.include('event_stores'))}
 	get stripe_payments(): StripePaymentInclude { return new StripePaymentInclude(this.include('stripe_payments'))}
 }
@@ -1230,7 +1138,6 @@ class StripeGatewayInclude extends ResourceInclude {
 class StripePaymentInclude extends ResourceInclude {
 	get order(): OrderInclude { return new OrderInclude(this.include('order'))}
 	get payment_gateway(): PaymentGatewayInclude { return new PaymentGatewayInclude(this.include('payment_gateway'))}
-	get versions(): VersionInclude { return new VersionInclude(this.include('versions'))}
 	get event_stores(): EventStoreInclude { return new EventStoreInclude(this.include('event_stores'))}
 }
 
@@ -1239,7 +1146,6 @@ class StripeTaxAccountInclude extends ResourceInclude {
 	get markets(): MarketInclude { return new MarketInclude(this.include('markets'))}
 	get attachments(): AttachmentInclude { return new AttachmentInclude(this.include('attachments'))}
 	get events(): EventInclude { return new EventInclude(this.include('events'))}
-	get versions(): VersionInclude { return new VersionInclude(this.include('versions'))}
 	get event_stores(): EventStoreInclude { return new EventStoreInclude(this.include('event_stores'))}
 	get tax_categories(): TaxCategoryInclude { return new TaxCategoryInclude(this.include('tax_categories'))}
 }
@@ -1262,7 +1168,6 @@ class TalonOneAccountInclude extends ResourceInclude {
 	get markets(): MarketInclude { return new MarketInclude(this.include('markets'))}
 	get discount_engine_items(): DiscountEngineItemInclude { return new DiscountEngineItemInclude(this.include('discount_engine_items'))}
 	get attachments(): AttachmentInclude { return new AttachmentInclude(this.include('attachments'))}
-	get versions(): VersionInclude { return new VersionInclude(this.include('versions'))}
 	get event_stores(): EventStoreInclude { return new EventStoreInclude(this.include('event_stores'))}
 }
 
@@ -1271,7 +1176,6 @@ class TaxCalculatorInclude extends ResourceInclude {
 	get markets(): MarketInclude { return new MarketInclude(this.include('markets'))}
 	get attachments(): AttachmentInclude { return new AttachmentInclude(this.include('attachments'))}
 	get events(): EventInclude { return new EventInclude(this.include('events'))}
-	get versions(): VersionInclude { return new VersionInclude(this.include('versions'))}
 	get event_stores(): EventStoreInclude { return new EventStoreInclude(this.include('event_stores'))}
 }
 
@@ -1280,14 +1184,12 @@ class TaxCategoryInclude extends ResourceInclude {
 	get sku(): SkuInclude { return new SkuInclude(this.include('sku'))}
 	get tax_calculator(): TaxCalculatorInclude { return new TaxCalculatorInclude(this.include('tax_calculator'))} // polymorphic
 	get attachments(): AttachmentInclude { return new AttachmentInclude(this.include('attachments'))}
-	get versions(): VersionInclude { return new VersionInclude(this.include('versions'))}
 	get event_stores(): EventStoreInclude { return new EventStoreInclude(this.include('event_stores'))}
 }
 
 
 class TaxRuleInclude extends ResourceInclude {
 	get manual_tax_calculator(): ManualTaxCalculatorInclude { return new ManualTaxCalculatorInclude(this.include('manual_tax_calculator'))}
-	get versions(): VersionInclude { return new VersionInclude(this.include('versions'))}
 	get event_stores(): EventStoreInclude { return new EventStoreInclude(this.include('event_stores'))}
 }
 
@@ -1296,7 +1198,6 @@ class TaxjarAccountInclude extends ResourceInclude {
 	get markets(): MarketInclude { return new MarketInclude(this.include('markets'))}
 	get attachments(): AttachmentInclude { return new AttachmentInclude(this.include('attachments'))}
 	get events(): EventInclude { return new EventInclude(this.include('events'))}
-	get versions(): VersionInclude { return new VersionInclude(this.include('versions'))}
 	get event_stores(): EventStoreInclude { return new EventStoreInclude(this.include('event_stores'))}
 	get tax_categories(): TaxCategoryInclude { return new TaxCategoryInclude(this.include('tax_categories'))}
 }
@@ -1306,12 +1207,6 @@ class TransactionInclude extends ResourceInclude {
 	get order(): OrderInclude { return new OrderInclude(this.include('order'))}
 	get attachments(): AttachmentInclude { return new AttachmentInclude(this.include('attachments'))}
 	get events(): EventInclude { return new EventInclude(this.include('events'))}
-	get versions(): VersionInclude { return new VersionInclude(this.include('versions'))}
-	get event_stores(): EventStoreInclude { return new EventStoreInclude(this.include('event_stores'))}
-}
-
-
-class VersionInclude extends ResourceInclude {
 	get event_stores(): EventStoreInclude { return new EventStoreInclude(this.include('event_stores'))}
 }
 
@@ -1320,7 +1215,6 @@ class VertexAccountInclude extends ResourceInclude {
 	get markets(): MarketInclude { return new MarketInclude(this.include('markets'))}
 	get attachments(): AttachmentInclude { return new AttachmentInclude(this.include('attachments'))}
 	get events(): EventInclude { return new EventInclude(this.include('events'))}
-	get versions(): VersionInclude { return new VersionInclude(this.include('versions'))}
 	get event_stores(): EventStoreInclude { return new EventStoreInclude(this.include('event_stores'))}
 }
 
@@ -1329,7 +1223,6 @@ class VoidInclude extends ResourceInclude {
 	get order(): OrderInclude { return new OrderInclude(this.include('order'))}
 	get attachments(): AttachmentInclude { return new AttachmentInclude(this.include('attachments'))}
 	get events(): EventInclude { return new EventInclude(this.include('events'))}
-	get versions(): VersionInclude { return new VersionInclude(this.include('versions'))}
 	get event_stores(): EventStoreInclude { return new EventStoreInclude(this.include('event_stores'))}
 	get reference_authorization(): AuthorizationInclude { return new AuthorizationInclude(this.include('reference_authorization'))}
 }
@@ -1337,14 +1230,12 @@ class VoidInclude extends ResourceInclude {
 
 class WebhookInclude extends ResourceInclude {
 	get last_event_callbacks(): EventCallbackInclude { return new EventCallbackInclude(this.include('last_event_callbacks'))}
-	get versions(): VersionInclude { return new VersionInclude(this.include('versions'))}
 	get event_stores(): EventStoreInclude { return new EventStoreInclude(this.include('event_stores'))}
 }
 
 
 class WireTransferInclude extends ResourceInclude {
 	get order(): OrderInclude { return new OrderInclude(this.include('order'))}
-	get versions(): VersionInclude { return new VersionInclude(this.include('versions'))}
 	get event_stores(): EventStoreInclude { return new EventStoreInclude(this.include('event_stores'))}
 }
 
@@ -1481,7 +1372,6 @@ export class IncludeHelper {
 	get tax_rules(): TaxRuleInclude { return new TaxRuleInclude() }
 	get taxjar_accounts(): TaxjarAccountInclude { return new TaxjarAccountInclude() }
 	get transactions(): TransactionInclude { return new TransactionInclude() }
-	get versions(): VersionInclude { return new VersionInclude() }
 	get vertex_accounts(): VertexAccountInclude { return new VertexAccountInclude() }
 	get voids(): VoidInclude { return new VoidInclude() }
 	get webhooks(): WebhookInclude { return new WebhookInclude() }


### PR DESCRIPTION
Closes #57

## Summary

- **Remove `versions` resource** — the `Version` resource has been removed from the Commerce Layer API. This includes: the `VersionInclude` class, the `VersionFilterFields` class and its `VersionFilter` type, all `get versions()` getters across 50+ resource include classes, and the top-level entries from both `IncludeHelper` and `FilterHelper`.

- **Add new fields and relationships** aligned with the updated API schema:
  - `ExportFilterFields`: added `processed_count` filter field
  - `ShippingWeightTierFilterFields`: added `events` relationship
  - `ShippingWeightTierInclude`: added `events` relationship

- **Fix `QuerySort` type cast** — in `src/all.ts`, the `.sort` field cast has been updated from `QueryParamsList<R>['sort']` to the explicit `QuerySort<R>` type exported by the SDK, improving readability without any runtime impact.

- **Bump dev dependencies** — `@commercelayer/sdk` → `^7.11.0`, `@commercelayer/js-auth` → `^7.4.2`, plus minor bumps for `@types/node`, `vitest`, `@vitest/coverage-v8`, `tsx`, and `semantic-release`.

- **Update CI workflows** — added `vulnerability-updates.yml` and updated `codeql-analysis.yml`, `publish.yml`, `semantic-release.yml`.

## Breaking changes

> Any consumer using `.versions` in include or filter helpers will get a TypeScript error. The resource is no longer available in the Commerce Layer API.
